### PR TITLE
[Add] Support for Import and Diff Suppression

### DIFF
--- a/incapsula/diff_suppress_funcs.go
+++ b/incapsula/diff_suppress_funcs.go
@@ -1,0 +1,18 @@
+package incapsula
+
+import (
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func suppressEquivalentStringDiffs(k, old, new string, d *schema.ResourceData) bool {
+	oldSlice := strings.Split(old, ",")
+	newSlice := strings.Split(new, ",")
+	sort.Strings(oldSlice)
+	sort.Strings(newSlice)
+
+	return reflect.DeepEqual(oldSlice, newSlice)
+}

--- a/incapsula/resource_site_test.go
+++ b/incapsula/resource_site_test.go
@@ -28,6 +28,24 @@ func TestAccIncapsulaSite_Basic(t *testing.T) {
 	})
 }
 
+func TestAccIncapsulaSite_ImportBasic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIncapsulaSiteDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIncapsulaSiteConfig_basic(testAccDomain),
+			},
+			{
+				ResourceName:      "incapsula_site.testacc-terraform-site",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckIncapsulaSiteDestroy(state *terraform.State) error {
 	client := testAccProvider.Meta().(*Client)
 


### PR DESCRIPTION
Here is he basics that I needed to use the provider in our already functional environment.  This adds support for Import on both Site and Rule

site you pass in the `site_id` for example `1002431`
rules you pass in `site_id/rule_id` for example `1002431/api.acl.blacklisted_ips`

Please let me know if you have changes, comments
