### PR TITLE
[Fix] Remove diff suppression on urls

### DIFF
--- a/incapsula/resource_incapsula_acl_security_rule.go
+++ b/incapsula/resource_incapsula_acl_security_rule.go
@@ -60,10 +60,9 @@ func resourceACLSecurityRule() *schema.Resource {
 				DiffSuppressFunc: suppressEquivalentStringDiffs,
 			},
 			"urls": &schema.Schema{
-				Description:      "A comma separated list of resource paths.",
-				Type:             schema.TypeString,
-				Optional:         true,
-				DiffSuppressFunc: suppressEquivalentStringDiffs,
+				Description: "A comma separated list of resource paths. NOTE: this is a 1:1 list with url_patterns e.q:  urls = \"Test,/Values\" url_patterns = \"CONTAINS,PREFIX\"",
+				Type:        schema.TypeString,
+				Optional:    true,
 			},
 			"url_patterns": &schema.Schema{
 				Description: "The patterns should be in accordance with the matching urls sent by the urls parameter. Options: CONTAINS | EQUALS | PREFIX | SUFFIX | NOT_EQUALS | NOT_CONTAIN | NOT_PREFIX | NOT_SUFFIX",


### PR DESCRIPTION
url and url_patterns are a 1:1 list. Which means order matters. 