### PR TITLE
fix the exposed secret in terraform state file

### DIFF
--- a/incapsula/resource_certificate.go
+++ b/incapsula/resource_certificate.go
@@ -35,14 +35,14 @@ func resourceCertificate() *schema.Resource {
 			},
 			// Optional Arguments
 			"private_key": {
-				Description: "The private key of the certificate in base64 format. Optional in case of PFX certificate file format.",
+				Description: "The private key of the certificate in base64 format. Optional in case of PFX certificate file format. This will be encoded in sha256 in terraform state.",
 				Type:        schema.TypeString,
 				Required:    true,
 				Sensitive:   true,
 				StateFunc:   sha256Encode,
 			},
 			"passphrase": {
-				Description: "The passphrase used to protect your SSL certificate.",
+				Description: "The passphrase used to protect your SSL certificate. This will be encoded in sha256 in terraform state.",
 				Type:        schema.TypeString,
 				Required:    true,
 				Sensitive:   true,


### PR DESCRIPTION
@anandkunal @banderson0421 This is to fix the secret (private key and passphrase) that will be exposed in terraform state file once the tls certificates has been uploaded.