### PR TITLE
Update WAF security import to pull in existing data

### DIFF
--- a/incapsula/client_waf_security_rule.go
+++ b/incapsula/client_waf_security_rule.go
@@ -20,6 +20,7 @@ const remoteFileInclusionRuleID = "api.threats.remote_file_inclusion"
 const sqlInjectionRuleID = "api.threats.sql_injection"
 const ddosRuleID = "api.threats.ddos"
 const botAccessControlRuleID = "api.threats.bot_access_control"
+const customRuleDefaultActionID = "api.threats.customRule"
 
 // ConfigureWAFSecurityRule adds an WAF rule
 func (c *Client) ConfigureWAFSecurityRule(siteID int, ruleID, securityRuleAction, activationMode, ddosTrafficThreshold, blockBadBots, challengeSuspectedBots string) (*SiteStatusResponse, error) {

--- a/incapsula/resource_waf_security_rule.go
+++ b/incapsula/resource_waf_security_rule.go
@@ -175,28 +175,29 @@ func resourceWAFSecurityRuleRead(d *schema.ResourceData, m interface{}) error {
 	}
 
 	found := false
-
 	// Now with the site status, iterate through the rules and find our ID
 	for _, entry := range siteStatusResponse.Security.Waf.Rules {
 		if entry.ID == d.Get("rule_id").(string) {
 			// Set different attributes based on the rule id
 			switch entry.ID {
 			case backdoorRuleID:
-				d.Set("action", entry.Action)
+				d.Set("security_rule_action", entry.Action)
 			case crossSiteScriptingRuleID:
-				d.Set("action", entry.Action)
+				d.Set("security_rule_action", entry.Action)
+			case customRuleDefaultActionID:
+				d.Set("security_rule_action", entry.Action)
 			case illegalResourceAccessRuleID:
-				d.Set("action", entry.Action)
+				d.Set("security_rule_action", entry.Action)
 			case remoteFileInclusionRuleID:
-				d.Set("action", entry.Action)
+				d.Set("security_rule_action", entry.Action)
 			case sqlInjectionRuleID:
-				d.Set("action", entry.Action)
+				d.Set("security_rule_action", entry.Action)
 			case ddosRuleID:
 				d.Set("activation_mode", entry.ActivationMode)
-				d.Set("ddos_traffic_threshold", entry.DdosTrafficThreshold)
+				d.Set("ddos_traffic_threshold", strconv.FormatInt(int64(entry.DdosTrafficThreshold), 10))
 			case botAccessControlRuleID:
-				d.Set("block_bad_bots", entry.BlockBadBots)
-				d.Set("block_bad_bots", entry.ChallengeSuspectedBots)
+				d.Set("block_bad_bots", strconv.FormatBool(entry.BlockBadBots))
+				d.Set("challenge_suspected_bots", strconv.FormatBool(entry.ChallengeSuspectedBots))
 			}
 			found = true
 			break


### PR DESCRIPTION
Currently, when importing a WAF security rule, only the site and rule
id. The import logic needs to be updated to read the existing rule from
incapsula to prevent any needed changes upon planning. After importing,
all the fields are left as null. When updating the import logic to
perform a read after populating the proper IDs, all the fields are
populated correctly now upon import.

Closes #37 

### Example result from import after these changes
```
    {
      "mode": "managed",
      "type": "incapsula_waf_security_rule",
      "name": "wiki-audaxhealth-com-waf-rule-bot-access-control",
      "provider": "provider.incapsula",
      "instances": [
        {
          "schema_version": 0,
          "attributes": {
            "activation_mode": null,
            "block_bad_bots": "true",
            "challenge_suspected_bots": "false",
            "ddos_traffic_threshold": null,
            "id": "12734028/api.threats.bot_access_control",
            "rule_id": "api.threats.bot_access_control",
            "security_rule_action": null,
            "site_id": 9999999
          },
          "private": "<removed>"
        }
      ]
    },
```