### PR TITLE
Update incap_rules to not enforce filter parameter on simplfied redir…

### DIFF
--- a/incapsula/client_incap_rule.go
+++ b/incapsula/client_incap_rule.go
@@ -13,7 +13,7 @@ import (
 type IncapRule struct {
 	Name                string `json:"name"`
 	Action              string `json:"action"`
-	Filter              string `json:"filter"`
+	Filter              string `json:"filter,omitempty"`
 	ResponseCode        int    `json:"response_code,omitempty"`
 	AddMissing          bool   `json:"add_missing,omitempty"`
 	From                string `json:"from,omitempty"`

--- a/incapsula/resource_incap_rule.go
+++ b/incapsula/resource_incap_rule.go
@@ -48,12 +48,12 @@ func resourceIncapRule() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 			},
+			// Optional Arguments
 			"filter": {
 				Description: "The filter defines the conditions that trigger the rule action. For action `RULE_ACTION_SIMPLIFIED_REDIRECT` filter is not relevant. For other actions, if left empty, the rule is always run.",
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 			},
-			// Optional Arguments
 			"response_code": {
 				Description: "For `RULE_ACTION_REDIRECT` or `RULE_ACTION_SIMPLIFIED_REDIRECT` rule's response code, valid values are `302`, `301`, `303`, `307`, `308`. For `RULE_ACTION_RESPONSE_REWRITE_RESPONSE_CODE` rule's response code, valid values are all 3-digits numbers. For `RULE_ACTION_CUSTOM_ERROR_RESPONSE`, valid values are `400`, `401`, `402`, `403`, `404`, `405`, `406`, `407`, `408`, `409`, `410`, `411`, `412`, `413`, `414`, `415`, `416`, `417`, `419`, `420`, `422`, `423`, `424`, `500`, `501`, `502`, `503`, `504`, `505`, `507`.",
 				Type:        schema.TypeInt,


### PR DESCRIPTION
The Terraform provider is enforcing the "filter" parameter, which is in contrast to the API expectations for the RULE_ACTION_SIMPLIFIED_REDIRECT action.

message from Terraform:, when excluding the filter parameter or setting value as null:

Error: "filter": required field is not set

 on incap_rules.tf line 25, in resource "incapsula_incap_rule" "simplified-redirect":
 25: resource "incapsula_incap_rule" "simplified-redirect” {


message from API:
{
  "res": 2,
  "res_message": "Invalid input",
  "debug_info": {
    "Add rule failed": "Fields: {filter} should be null for RULE_ACTION_SIMPLIFIED_REDIRECT",
    "id-info": "13008"
  }
}