### PR TITLE
Add 'Account' resource and functions

### DIFF
--- a/incapsula/client.go
+++ b/incapsula/client.go
@@ -1,0 +1,65 @@
+package incapsula
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/url"
+)
+
+// Client represents an internal client that brokers calls to the Incapsula API
+type Client struct {
+	config     *Config
+	httpClient *http.Client
+}
+
+// NewClient creates a new client with the provided configuration
+func NewClient(config *Config) *Client {
+	client := &http.Client{}
+	return &Client{config: config, httpClient: client}
+}
+
+// Verify checks the API credentials
+func (c *Client) Verify() (*AccountStatusResponse, error) {
+	log.Println("[INFO] Checking API credentials against Incapsula API")
+
+	// Post form to Incapsula
+	resp, err := c.httpClient.PostForm(fmt.Sprintf("%s/%s", c.config.BaseURL, endpointAccountStatus), url.Values{
+		"api_id":  {c.config.APIID},
+		"api_key": {c.config.APIKey},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("Error checking account: %s", err)
+	}
+
+	// Read the body
+	defer resp.Body.Close()
+	responseBody, err := ioutil.ReadAll(resp.Body)
+
+	// Dump JSON
+	log.Printf("[DEBUG] Incapsula account JSON response: %s\n", string(responseBody))
+
+	// Parse the JSON
+	var accountStatusResponse AccountStatusResponse
+	err = json.Unmarshal([]byte(responseBody), &accountStatusResponse)
+	if err != nil {
+		return nil, fmt.Errorf("Error parsing account JSON response: %s", err)
+	}
+
+	var resString string
+
+	if resNumber, ok := accountStatusResponse.Res.(float64); ok {
+		resString = fmt.Sprintf("%d", int(resNumber))
+	} else {
+		resString = accountStatusResponse.Res.(string)
+	}
+
+	// Look at the response status code from Incapsula
+	if resString != "0" {
+		return &accountStatusResponse, fmt.Errorf("Error from Incapsula service when checking account: %s", string(responseBody))
+	}
+
+	return &accountStatusResponse, nil
+}

--- a/incapsula/client_account_data_storage_region.go
+++ b/incapsula/client_account_data_storage_region.go
@@ -1,0 +1,95 @@
+package incapsula
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/url"
+)
+
+const endpointAccountDataStorageRegionGet = "accounts/data-privacy/show"
+const endpointAccountDataStorageRegionUpdate = "accounts/data-privacy/set-region-default"
+
+// AccountDataStorageRegionResponse contains the relevant information when getting/setting a default data storage region
+type AccountDataStorageRegionResponse struct {
+	Region     string `json:"region"`
+	Res        int    `json:"res"`
+	ResMessage string `json:"res_message"`
+	DebugInfo  struct {
+		IDInfo string `json:"id-info"`
+	} `json:"debug_info"`
+}
+
+// GetAccountDataStorageRegion gets the default data storage region for sites in the account
+func (c *Client) GetAccountDataStorageRegion(accountID string) (*AccountDataStorageRegionResponse, error) {
+	log.Printf("[INFO] Getting default Incapsula data storage region for account: %s\n", accountID)
+
+	// Post form to Incapsula
+	resp, err := c.httpClient.PostForm(fmt.Sprintf("%s/%s", c.config.BaseURL, endpointAccountDataStorageRegionGet), url.Values{
+		"api_id":     {c.config.APIID},
+		"api_key":    {c.config.APIKey},
+		"account_id": {accountID},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("Error getting default data storage region for account id: %s: %s", accountID, err)
+	}
+
+	// Read the body
+	defer resp.Body.Close()
+	responseBody, err := ioutil.ReadAll(resp.Body)
+
+	// Dump JSON
+	log.Printf("[DEBUG] Incapsula default data storage region JSON response: %s\n", string(responseBody))
+
+	// Parse the JSON
+	var accountDataStorageRegionResponse AccountDataStorageRegionResponse
+	err = json.Unmarshal([]byte(responseBody), &accountDataStorageRegionResponse)
+	if err != nil {
+		return nil, fmt.Errorf("Error parsing default data storage region JSON response for account id: %s: %s", accountID, err)
+	}
+
+	// Look at the response status code from Incapsula
+	if accountDataStorageRegionResponse.Res != 0 {
+		return &accountDataStorageRegionResponse, fmt.Errorf("Error from Incapsula service when getting default data storage region for account id: %s: %s", accountID, string(responseBody))
+	}
+
+	return &accountDataStorageRegionResponse, nil
+}
+
+// UpdateAccountDataStorageRegion will update the default data storage region on the account
+func (c *Client) UpdateAccountDataStorageRegion(accountID, region string) (*AccountDataStorageRegionResponse, error) {
+	log.Printf("[INFO] Updating Incapsula default data storage region (%s) for accountID: %s\n", region, accountID)
+
+	// Post form to Incapsula
+	resp, err := c.httpClient.PostForm(fmt.Sprintf("%s/%s", c.config.BaseURL, endpointAccountDataStorageRegionUpdate), url.Values{
+		"api_id":              {c.config.APIID},
+		"api_key":             {c.config.APIKey},
+		"account_id":          {accountID},
+		"data_storage_region": {region},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("Error updating data storage region with value (%s) on account_id: %s: %s", region, accountID, err)
+	}
+
+	// Read the body
+	defer resp.Body.Close()
+	responseBody, err := ioutil.ReadAll(resp.Body)
+
+	// Dump JSON
+	log.Printf("[DEBUG] Incapsula update account default data storage region JSON response: %s\n", string(responseBody))
+
+	// Parse the JSON
+	var accountDataStorageRegionResponse AccountDataStorageRegionResponse
+	err = json.Unmarshal([]byte(responseBody), &accountDataStorageRegionResponse)
+	if err != nil {
+		return nil, fmt.Errorf("Error parsing update default data storage region JSON response for accountID %s: %s", accountID, err)
+	}
+
+	// Look at the response status code from Incapsula
+	if accountDataStorageRegionResponse.Res != 0 {
+		return nil, fmt.Errorf("Error from Incapsula service when updating default data storage region for accountID %s: %s", accountID, string(responseBody))
+	}
+
+	return &accountDataStorageRegionResponse, nil
+}

--- a/incapsula/client_account_data_storage_region_test.go
+++ b/incapsula/client_account_data_storage_region_test.go
@@ -1,0 +1,204 @@
+package incapsula
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+////////////////////////////////////////////////////////////////
+// GetAccountDataStorageRegion Tests
+////////////////////////////////////////////////////////////////
+
+func TestClientGetAccountDataStorageRegionBadConnection(t *testing.T) {
+	config := &Config{APIID: "foo", APIKey: "bar", BaseURL: "badness.incapsula.com"}
+	client := &Client{config: config, httpClient: &http.Client{Timeout: time.Millisecond * 1}}
+	accountID := "123"
+	dataStorageRegionResponse, err := client.GetAccountDataStorageRegion(accountID)
+	if err == nil {
+		t.Errorf("Should have received an error")
+	}
+	if !strings.HasPrefix(err.Error(), fmt.Sprintf("Error getting default data storage region for account id: %s", accountID)) {
+		t.Errorf("Should have received an client error, got: %s", err)
+	}
+	if dataStorageRegionResponse != nil {
+		t.Errorf("Should have received a nil dataStorageRegionResponse instance")
+	}
+}
+
+func TestClientGetAccountDataStorageRegionBadJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if req.URL.String() != fmt.Sprintf("/%s", endpointAccountDataStorageRegionGet) {
+			t.Errorf("Should have have hit /%s endpoint. Got: %s", endpointAccountDataStorageRegionGet, req.URL.String())
+		}
+		rw.Write([]byte(`{`))
+	}))
+	defer server.Close()
+
+	config := &Config{APIID: "foo", APIKey: "bar", BaseURL: server.URL}
+	client := &Client{config: config, httpClient: &http.Client{}}
+	accountID := "123"
+	dataStorageRegionResponse, err := client.GetAccountDataStorageRegion(accountID)
+	if err == nil {
+		t.Errorf("Should have received an error")
+	}
+	if !strings.HasPrefix(err.Error(), fmt.Sprintf("Error parsing default data storage region JSON response for account id: %s", accountID)) {
+		t.Errorf("Should have received a JSON parse error, got: %s", err)
+	}
+	if dataStorageRegionResponse != nil {
+		t.Errorf("Should have received a nil dataStorageRegionResponse instance")
+	}
+}
+
+func TestClientGetAccountDataStorageRegionInvalidSite(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if req.URL.String() != fmt.Sprintf("/%s", endpointAccountDataStorageRegionGet) {
+			t.Errorf("Should have have hit /%s endpoint. Got: %s", endpointAccountDataStorageRegionGet, req.URL.String())
+		}
+		rw.Write([]byte(`{"res":9413,"res_message":"Unknown/unauthorized account_id","debug_info":{"account_id":"7289383","id-info":"13007"}}`))
+	}))
+	defer server.Close()
+
+	config := &Config{APIID: "foo", APIKey: "bar", BaseURL: server.URL}
+	client := &Client{config: config, httpClient: &http.Client{}}
+	accountID := "7289383"
+	dataStorageRegionResponse, err := client.GetAccountDataStorageRegion(accountID)
+	if err == nil {
+		t.Errorf("Should have received an error")
+	}
+	if !strings.HasPrefix(err.Error(), fmt.Sprintf("Error from Incapsula service when getting default data storage region for account id: %s", accountID)) {
+		t.Errorf("Should have received a bad account error, got: %s", err)
+	}
+	if dataStorageRegionResponse == nil {
+		t.Errorf("Should have received a dataStorageRegionResponse instance")
+	}
+}
+
+func TestClientGetAccountDataStorageRegionValidSite(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if req.URL.String() != fmt.Sprintf("/%s", endpointAccountDataStorageRegionGet) {
+			t.Errorf("Should have have hit /%s endpoint. Got: %s", endpointAccountDataStorageRegionGet, req.URL.String())
+		}
+		rw.Write([]byte(`{"region":"US","res":0,"res_message":"OK","debug_info":{"id-info":"13017"}}`))
+	}))
+	defer server.Close()
+
+	config := &Config{APIID: "foo", APIKey: "bar", BaseURL: server.URL}
+	client := &Client{config: config, httpClient: &http.Client{}}
+	accountID := "123"
+	dataStorageRegionResponse, err := client.GetAccountDataStorageRegion(accountID)
+	if err != nil {
+		t.Errorf("Should not have received an error")
+	}
+	if dataStorageRegionResponse == nil {
+		t.Errorf("Should not have received a nil dataStorageRegionResponse instance")
+	}
+	if dataStorageRegionResponse.Region != "US" {
+		t.Errorf("Data storage region doesn't match")
+	}
+	if dataStorageRegionResponse.Res != 0 {
+		t.Errorf("Data storage result code doesn't match")
+	}
+}
+
+////////////////////////////////////////////////////////////////
+// UpdateSite Tests
+////////////////////////////////////////////////////////////////
+
+func TestClientUpdateAccountDataStorageRegionBadConnection(t *testing.T) {
+	config := &Config{APIID: "foo", APIKey: "bar", BaseURL: "badness.incapsula.com"}
+	client := &Client{config: config, httpClient: &http.Client{Timeout: time.Millisecond * 1}}
+	accountID := "42"
+	region := "US"
+	dataStorageRegionResponse, err := client.UpdateAccountDataStorageRegion(accountID, region)
+	if err == nil {
+		t.Errorf("Should have received an error")
+	}
+	if !strings.HasPrefix(err.Error(), fmt.Sprintf("Error updating data storage region with value (%s) on account_id: %s", region, accountID)) {
+		t.Errorf("Should have received an client error, got: %s", err)
+	}
+	if dataStorageRegionResponse != nil {
+		t.Errorf("Should have received a nil dataStorageRegionResponse instance")
+	}
+}
+
+func TestClientUpdateAccountDataStorageRegionBadJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if req.URL.String() != fmt.Sprintf("/%s", endpointAccountDataStorageRegionUpdate) {
+			t.Errorf("Should have have hit /%s endpoint. Got: %s", endpointAccountDataStorageRegionUpdate, req.URL.String())
+		}
+		rw.Write([]byte(`{`))
+	}))
+	defer server.Close()
+
+	config := &Config{APIID: "foo", APIKey: "bar", BaseURL: server.URL}
+	client := &Client{config: config, httpClient: &http.Client{}}
+	accountID := "42"
+	region := "US"
+	dataStorageRegionResponse, err := client.UpdateAccountDataStorageRegion(accountID, region)
+	if err == nil {
+		t.Errorf("Should have received an error")
+	}
+	if !strings.HasPrefix(err.Error(), fmt.Sprintf("Error parsing update default data storage region JSON response for accountID %s", accountID)) {
+		t.Errorf("Should have received a JSON parse error, got: %s", err)
+	}
+	if dataStorageRegionResponse != nil {
+		t.Errorf("Should have received a nil dataStorageRegionResponse instance")
+	}
+}
+
+func TestClientUpdateAccountDataStorageRegionInvalidSite(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if req.URL.String() != fmt.Sprintf("/%s", endpointAccountDataStorageRegionUpdate) {
+			t.Errorf("Should have have hit /%s endpoint. Got: %s", endpointAccountDataStorageRegionUpdate, req.URL.String())
+		}
+		rw.Write([]byte(`{"res":9413,"res_message":"Unknown/unauthorized account_id","debug_info":{"account_id":"7293873","id-info":"13008"}}`))
+	}))
+	defer server.Close()
+
+	config := &Config{APIID: "foo", APIKey: "bar", BaseURL: server.URL}
+	client := &Client{config: config, httpClient: &http.Client{}}
+	accountID := "7293873"
+	region := "US"
+	dataStorageRegionResponse, err := client.UpdateAccountDataStorageRegion(accountID, region)
+	if err == nil {
+		t.Errorf("Should have received an error")
+	}
+	if !strings.HasPrefix(err.Error(), fmt.Sprintf("Error from Incapsula service when updating default data storage region for accountID %s", accountID)) {
+		t.Errorf("Should have received a bad account error, got: %s", err)
+	}
+	if dataStorageRegionResponse != nil {
+		t.Errorf("Should have received a nil dataStorageRegionResponse instance")
+	}
+}
+
+func TestClientUpdateAccountDataStorageRegionValidSite(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if req.URL.String() != fmt.Sprintf("/%s", endpointAccountDataStorageRegionUpdate) {
+			t.Errorf("Should have have hit /%s endpoint. Got: %s", endpointAccountDataStorageRegionUpdate, req.URL.String())
+		}
+		rw.Write([]byte(`{"region":"US","res":0,"res_message":"OK","debug_info":{"id-info":"13017"}}`))
+	}))
+	defer server.Close()
+
+	config := &Config{APIID: "foo", APIKey: "bar", BaseURL: server.URL}
+	client := &Client{config: config, httpClient: &http.Client{}}
+	accountID := "7293873"
+	region := "US"
+	dataStorageRegionResponse, err := client.UpdateAccountDataStorageRegion(accountID, region)
+	if err != nil {
+		t.Errorf("Should not have received an error")
+	}
+	if dataStorageRegionResponse == nil {
+		t.Errorf("Should not have received a nil dataStorageRegionResponse instance")
+	}
+	if dataStorageRegionResponse.Region != "US" {
+		t.Errorf("Region doesn't match")
+	}
+	if dataStorageRegionResponse.Res != 0 {
+		t.Errorf("Response code doesn't match")
+	}
+}

--- a/incapsula/client_account_test.go
+++ b/incapsula/client_account_test.go
@@ -10,24 +10,29 @@ import (
 )
 
 ////////////////////////////////////////////////////////////////
-// Verify Tests
+// AddAccount Tests
 ////////////////////////////////////////////////////////////////
-func TestClientVerifyBadConnection(t *testing.T) {
+
+func TestClientAddAccountBadConnection(t *testing.T) {
 	config := &Config{APIID: "foo", APIKey: "bar", BaseURL: "badness.incapsula.com"}
 	client := &Client{config: config, httpClient: &http.Client{Timeout: time.Millisecond * 1}}
-	_, err := client.Verify()
+	email := "example@example.com"
+	addAccountResponse, err := client.AddAccount(email, "", "", "", "", "", 0, 0)
 	if err == nil {
 		t.Errorf("Should have received an error")
 	}
-	if !strings.HasPrefix(err.Error(), "Error checking account") {
+	if !strings.HasPrefix(err.Error(), fmt.Sprintf("Error adding account for email %s", email)) {
 		t.Errorf("Should have received an client error, got: %s", err)
+	}
+	if addAccountResponse != nil {
+		t.Errorf("Should have received a nil addAccountResponse instance")
 	}
 }
 
-func TestClientVerifyBadJSON(t *testing.T) {
+func TestClientAddAccountBadJSON(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		if req.URL.String() != fmt.Sprintf("/%s", endpointAccount) {
-			t.Errorf("Should have have hit /%s endpoint. Got: %s", endpointAccount, req.URL.String())
+		if req.URL.String() != fmt.Sprintf("/%s", endpointAccountAdd) {
+			t.Errorf("Should have have hit /%s endpoint. Got: %s", endpointAccountAdd, req.URL.String())
 		}
 		rw.Write([]byte(`{`))
 	}))
@@ -35,19 +40,301 @@ func TestClientVerifyBadJSON(t *testing.T) {
 
 	config := &Config{APIID: "foo", APIKey: "bar", BaseURL: server.URL}
 	client := &Client{config: config, httpClient: &http.Client{}}
-	_, err := client.Verify()
+	email := "example@example.com"
+	addAccountResponse, err := client.AddAccount(email, "", "", "", "", "", 0, 0)
 	if err == nil {
 		t.Errorf("Should have received an error")
 	}
-	if !strings.HasPrefix(err.Error(), "Error parsing account JSON response") {
+	if !strings.HasPrefix(err.Error(), fmt.Sprintf("Error parsing add account JSON response for email %s", email)) {
+		t.Errorf("Should have received a JSON parse error, got: %s", err)
+	}
+	if addAccountResponse != nil {
+		t.Errorf("Should have received a nil addAccountResponse instance")
+	}
+}
+
+func TestClientAddAccountInvalidParent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if req.URL.String() != fmt.Sprintf("/%s", endpointAccountAdd) {
+			t.Errorf("Should have have hit /%s endpoint. Got: %s", endpointAccountAdd, req.URL.String())
+		}
+		rw.Write([]byte(`{"parent_id":0,"res":1}`))
+	}))
+	defer server.Close()
+
+	config := &Config{APIID: "foo", APIKey: "bar", BaseURL: server.URL}
+	client := &Client{config: config, httpClient: &http.Client{}}
+	email := "example@example.com"
+	addAccountResponse, err := client.AddAccount(email, "", "", "", "", "", 0, 0)
+	if err == nil {
+		t.Errorf("Should have received an error")
+	}
+	if !strings.HasPrefix(err.Error(), fmt.Sprintf("Error from Incapsula service when adding account for email %s", email)) {
+		t.Errorf("Should have received a bad account error, got: %s", err)
+	}
+	if addAccountResponse != nil {
+		t.Errorf("Should have received a nil addAccountResponse instance")
+	}
+}
+
+func TestClientAddAccountValidParent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if req.URL.String() != fmt.Sprintf("/%s", endpointAccountAdd) {
+			t.Errorf("Should have have hit /%s endpoint. Got: %s", endpointAccountAdd, req.URL.String())
+		}
+		rw.Write([]byte(`{"Account": {"parent_id":123},"res":0}`))
+	}))
+	defer server.Close()
+
+	config := &Config{APIID: "foo", APIKey: "bar", BaseURL: server.URL}
+	client := &Client{config: config, httpClient: &http.Client{}}
+	email := "example@example.com"
+	addAccountResponse, err := client.AddAccount(email, "", "", "", "", "", 0, 0)
+	if err != nil {
+		t.Errorf("Should not have received an error")
+	}
+	if addAccountResponse == nil {
+		t.Errorf("Should not have received a nil addAccountResponse instance")
+	}
+	if addAccountResponse.Account.ParentID != 123 {
+		t.Errorf("Parent ID doesn't match")
+	}
+	if addAccountResponse.Res != 0 {
+		t.Errorf("Response code doesn't match")
+	}
+}
+
+////////////////////////////////////////////////////////////////
+// AccountStatus Tests
+////////////////////////////////////////////////////////////////
+
+func TestClientAccountStatusBadConnection(t *testing.T) {
+	config := &Config{APIID: "foo", APIKey: "bar", BaseURL: "badness.incapsula.com"}
+	client := &Client{config: config, httpClient: &http.Client{Timeout: time.Millisecond * 1}}
+	accountID := 123
+	accountStatusResponse, err := client.AccountStatus(accountID)
+	if err == nil {
+		t.Errorf("Should have received an error")
+	}
+	if !strings.HasPrefix(err.Error(), fmt.Sprintf("Error getting account status for account id %d", accountID)) {
+		t.Errorf("Should have received an client error, got: %s", err)
+	}
+	if accountStatusResponse != nil {
+		t.Errorf("Should have received a nil accountStatusResponse instance")
+	}
+}
+
+func TestClientAccountStatusBadJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if req.URL.String() != fmt.Sprintf("/%s", endpointAccountStatus) {
+			t.Errorf("Should have have hit /%s endpoint. Got: %s", endpointAccountStatus, req.URL.String())
+		}
+		rw.Write([]byte(`{`))
+	}))
+	defer server.Close()
+
+	config := &Config{APIID: "foo", APIKey: "bar", BaseURL: server.URL}
+	client := &Client{config: config, httpClient: &http.Client{}}
+	accountID := 123
+	accountStatusResponse, err := client.AccountStatus(accountID)
+	if err == nil {
+		t.Errorf("Should have received an error")
+	}
+	if !strings.HasPrefix(err.Error(), fmt.Sprintf("Error parsing account status JSON response for account id %d", accountID)) {
+		t.Errorf("Should have received a JSON parse error, got: %s", err)
+	}
+	if accountStatusResponse != nil {
+		t.Errorf("Should have received a nil accountStatusResponse instance")
+	}
+}
+
+func TestClientAccountStatusInvalidAccount(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if req.URL.String() != fmt.Sprintf("/%s", endpointAccountStatus) {
+			t.Errorf("Should have have hit /%s endpoint. Got: %s", endpointAccountStatus, req.URL.String())
+		}
+		rw.Write([]byte(`{"Account": {"trial_end_date":"0"}, "res":1}`))
+	}))
+	defer server.Close()
+
+	config := &Config{APIID: "foo", APIKey: "bar", BaseURL: server.URL}
+	client := &Client{config: config, httpClient: &http.Client{}}
+	accountID := 123
+	accountStatusResponse, err := client.AccountStatus(accountID)
+	if err == nil {
+		t.Errorf("Should have received an error")
+	}
+	if !strings.HasPrefix(err.Error(), fmt.Sprintf("Error from Incapsula service when getting account status for account id %d", accountID)) {
+		t.Errorf("Should have received a bad account error, got: %s", err)
+	}
+	if accountStatusResponse == nil {
+		t.Errorf("Should have received a accountStatusResponse instance")
+	}
+}
+
+func TestClientAccountStatusValidAccount(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if req.URL.String() != fmt.Sprintf("/%s", endpointAccountStatus) {
+			t.Errorf("Should have have hit /%s endpoint. Got: %s", endpointAccountStatus, req.URL.String())
+		}
+		rw.Write([]byte(`{"Account": {"trial_end_date":"May 28, 2014"}, "res":0}`))
+	}))
+	defer server.Close()
+
+	config := &Config{APIID: "foo", APIKey: "bar", BaseURL: server.URL}
+	client := &Client{config: config, httpClient: &http.Client{}}
+	accountID := 123
+	accountStatusResponse, err := client.AccountStatus(accountID)
+	if err != nil {
+		t.Errorf("Should not have received an error")
+	}
+	if accountStatusResponse == nil {
+		t.Errorf("Should not have received a nil accountStatusResponse instance")
+	}
+	if accountStatusResponse.Account.TrialEndDate != "May 28, 2014" {
+		t.Errorf("Account trial end date doesn't match")
+	}
+}
+
+////////////////////////////////////////////////////////////////
+// UpdateAccount Tests
+////////////////////////////////////////////////////////////////
+
+func TestClientUpdateAccountBadConnection(t *testing.T) {
+	config := &Config{APIID: "foo", APIKey: "bar", BaseURL: "badness.incapsula.com"}
+	client := &Client{config: config, httpClient: &http.Client{Timeout: time.Millisecond * 1}}
+	accountID := "42"
+	param := "error_page_template"
+	value := "ABC123"
+	updateAccountResponse, err := client.UpdateAccount(accountID, param, value)
+	if err == nil {
+		t.Errorf("Should have received an error")
+	}
+	if !strings.HasPrefix(err.Error(), fmt.Sprintf("Error updating param (%s) with value (%s) on account_id: %s", param, value, accountID)) {
+		t.Errorf("Should have received an client error, got: %s", err)
+	}
+	if updateAccountResponse != nil {
+		t.Errorf("Should have received a nil updateAccountResponse instance")
+	}
+}
+
+func TestClientUpdateAccountBadJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if req.URL.String() != fmt.Sprintf("/%s", endpointAccountUpdate) {
+			t.Errorf("Should have have hit /%s endpoint. Got: %s", endpointAccountUpdate, req.URL.String())
+		}
+		rw.Write([]byte(`{`))
+	}))
+	defer server.Close()
+
+	config := &Config{APIID: "foo", APIKey: "bar", BaseURL: server.URL}
+	client := &Client{config: config, httpClient: &http.Client{}}
+	accountID := "42"
+	updateAccountResponse, err := client.UpdateAccount(accountID, "", "")
+	if err == nil {
+		t.Errorf("Should have received an error")
+	}
+	if !strings.HasPrefix(err.Error(), fmt.Sprintf("Error parsing update account JSON response for accountID %s", accountID)) {
+		t.Errorf("Should have received a JSON parse error, got: %s", err)
+	}
+	if updateAccountResponse != nil {
+		t.Errorf("Should have received a nil updateAccountResponse instance")
+	}
+}
+
+func TestClientUpdateAccountInvalidAccount(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if req.URL.String() != fmt.Sprintf("/%s", endpointAccountUpdate) {
+			t.Errorf("Should have have hit /%s endpoint. Got: %s", endpointAccountUpdate, req.URL.String())
+		}
+		rw.Write([]byte(`{"account_id":0,"res":1}`))
+	}))
+	defer server.Close()
+
+	config := &Config{APIID: "foo", APIKey: "bar", BaseURL: server.URL}
+	client := &Client{config: config, httpClient: &http.Client{}}
+	accountID := "42"
+	updateAccountResponse, err := client.UpdateAccount(accountID, "", "")
+	if err == nil {
+		t.Errorf("Should have received an error")
+	}
+	if !strings.HasPrefix(err.Error(), fmt.Sprintf("Error from Incapsula service when updating account for accountID %s", accountID)) {
+		t.Errorf("Should have received a bad account error, got: %s", err)
+	}
+	if updateAccountResponse != nil {
+		t.Errorf("Should have received a nil updateAccountResponse instance")
+	}
+}
+
+func TestClientUpdateAccountValidAccount(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if req.URL.String() != fmt.Sprintf("/%s", endpointAccountUpdate) {
+			t.Errorf("Should have have hit /%s endpoint. Got: %s", endpointAccountUpdate, req.URL.String())
+		}
+		rw.Write([]byte(`{"account_id":123,"res":0}`))
+	}))
+	defer server.Close()
+
+	config := &Config{APIID: "foo", APIKey: "bar", BaseURL: server.URL}
+	client := &Client{config: config, httpClient: &http.Client{}}
+	accountID := "42"
+	updateAccountResponse, err := client.UpdateAccount(accountID, "", "")
+	if err != nil {
+		t.Errorf("Should not have received an error")
+	}
+	if updateAccountResponse == nil {
+		t.Errorf("Should not have received a nil updateAccountResponse instance")
+	}
+	if updateAccountResponse.AccountID != 123 {
+		t.Errorf("Account ID doesn't match")
+	}
+	if updateAccountResponse.Res != 0 {
+		t.Errorf("Response code doesn't match")
+	}
+}
+
+////////////////////////////////////////////////////////////////
+// DeleteAccount Tests
+////////////////////////////////////////////////////////////////
+
+func TestClientDeleteAccountBadConnection(t *testing.T) {
+	config := &Config{APIID: "foo", APIKey: "bar", BaseURL: "badness.incapsula.com"}
+	client := &Client{config: config, httpClient: &http.Client{Timeout: time.Millisecond * 1}}
+	accountID := 123
+	err := client.DeleteAccount(accountID)
+	if err == nil {
+		t.Errorf("Should have received an error")
+	}
+	if !strings.HasPrefix(err.Error(), fmt.Sprintf("Error deleting account id: %d", accountID)) {
+		t.Errorf("Should have received an client error, got: %s", err)
+	}
+}
+
+func TestClientDeleteAccountBadJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if req.URL.String() != fmt.Sprintf("/%s", endpointAccountDelete) {
+			t.Errorf("Should have have hit /%s endpoint. Got: %s", endpointAccountDelete, req.URL.String())
+		}
+		rw.Write([]byte(`{`))
+	}))
+	defer server.Close()
+
+	config := &Config{APIID: "foo", APIKey: "bar", BaseURL: server.URL}
+	client := &Client{config: config, httpClient: &http.Client{}}
+	accountID := 123
+	err := client.DeleteAccount(accountID)
+	if err == nil {
+		t.Errorf("Should have received an error")
+	}
+	if !strings.HasPrefix(err.Error(), fmt.Sprintf("Error parsing delete account JSON response for account id: %d", accountID)) {
 		t.Errorf("Should have received a JSON parse error, got: %s", err)
 	}
 }
 
-func TestClientVerifyInvalidAccount(t *testing.T) {
+func TestClientDeleteAccountInvalidAccount(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		if req.URL.String() != fmt.Sprintf("/%s", endpointAccount) {
-			t.Errorf("Should have have hit /%s endpoint. Got: %s", endpointAccount, req.URL.String())
+		if req.URL.String() != fmt.Sprintf("/%s", endpointAccountDelete) {
+			t.Errorf("Should have have hit /%s endpoint. Got: %s", endpointAccountDelete, req.URL.String())
 		}
 		rw.Write([]byte(`{"res":1,"res_message":"fail"}`))
 	}))
@@ -55,19 +342,20 @@ func TestClientVerifyInvalidAccount(t *testing.T) {
 
 	config := &Config{APIID: "foo", APIKey: "bar", BaseURL: server.URL}
 	client := &Client{config: config, httpClient: &http.Client{}}
-	_, err := client.Verify()
+	accountID := 123
+	err := client.DeleteAccount(accountID)
 	if err == nil {
 		t.Errorf("Should have received an error")
 	}
-	if !strings.HasPrefix(err.Error(), "Error from Incapsula service when checking account") {
+	if !strings.HasPrefix(err.Error(), fmt.Sprintf("Error from Incapsula service when deleting account id: %d", accountID)) {
 		t.Errorf("Should have received a bad account error, got: %s", err)
 	}
 }
 
-func TestClientVerifyValidAccount(t *testing.T) {
+func TestClientDeleteAccountValidAccount(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		if req.URL.String() != fmt.Sprintf("/%s", endpointAccount) {
-			t.Errorf("Should have have hit /%s endpoint. Got: %s", endpointAccount, req.URL.String())
+		if req.URL.String() != fmt.Sprintf("/%s", endpointAccountDelete) {
+			t.Errorf("Should have have hit /%s endpoint. Got: %s", endpointAccountDelete, req.URL.String())
 		}
 		rw.Write([]byte(`{"res":0,"res_message":"OK"}`))
 	}))
@@ -75,8 +363,9 @@ func TestClientVerifyValidAccount(t *testing.T) {
 
 	config := &Config{APIID: "foo", APIKey: "bar", BaseURL: server.URL}
 	client := &Client{config: config, httpClient: &http.Client{}}
-	_, err := client.Verify()
+	accountID := 123
+	err := client.DeleteAccount(accountID)
 	if err != nil {
-		t.Errorf("Should not have received an error, got: %s", err)
+		t.Errorf("Should not have received an error")
 	}
 }

--- a/incapsula/client_test.go
+++ b/incapsula/client_test.go
@@ -1,0 +1,82 @@
+package incapsula
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+////////////////////////////////////////////////////////////////
+// Verify Tests
+////////////////////////////////////////////////////////////////
+func TestClientVerifyBadConnection(t *testing.T) {
+	config := &Config{APIID: "foo", APIKey: "bar", BaseURL: "badness.incapsula.com"}
+	client := &Client{config: config, httpClient: &http.Client{Timeout: time.Millisecond * 1}}
+	_, err := client.Verify()
+	if err == nil {
+		t.Errorf("Should have received an error")
+	}
+	if !strings.HasPrefix(err.Error(), "Error checking account") {
+		t.Errorf("Should have received an client error, got: %s", err)
+	}
+}
+
+func TestClientVerifyBadJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if req.URL.String() != fmt.Sprintf("/%s", endpointAccountStatus) {
+			t.Errorf("Should have have hit /%s endpoint. Got: %s", endpointAccountStatus, req.URL.String())
+		}
+		rw.Write([]byte(`{`))
+	}))
+	defer server.Close()
+
+	config := &Config{APIID: "foo", APIKey: "bar", BaseURL: server.URL}
+	client := &Client{config: config, httpClient: &http.Client{}}
+	_, err := client.Verify()
+	if err == nil {
+		t.Errorf("Should have received an error")
+	}
+	if !strings.HasPrefix(err.Error(), "Error parsing account JSON response") {
+		t.Errorf("Should have received a JSON parse error, got: %s", err)
+	}
+}
+
+func TestClientVerifyInvalidAccount(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if req.URL.String() != fmt.Sprintf("/%s", endpointAccountStatus) {
+			t.Errorf("Should have have hit /%s endpoint. Got: %s", endpointAccountStatus, req.URL.String())
+		}
+		rw.Write([]byte(`{"res":1,"res_message":"fail"}`))
+	}))
+	defer server.Close()
+
+	config := &Config{APIID: "foo", APIKey: "bar", BaseURL: server.URL}
+	client := &Client{config: config, httpClient: &http.Client{}}
+	_, err := client.Verify()
+	if err == nil {
+		t.Errorf("Should have received an error")
+	}
+	if !strings.HasPrefix(err.Error(), "Error from Incapsula service when checking account") {
+		t.Errorf("Should have received a bad account error, got: %s", err)
+	}
+}
+
+func TestClientVerifyValidAccount(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if req.URL.String() != fmt.Sprintf("/%s", endpointAccountStatus) {
+			t.Errorf("Should have have hit /%s endpoint. Got: %s", endpointAccountStatus, req.URL.String())
+		}
+		rw.Write([]byte(`{"res":0,"res_message":"OK"}`))
+	}))
+	defer server.Close()
+
+	config := &Config{APIID: "foo", APIKey: "bar", BaseURL: server.URL}
+	client := &Client{config: config, httpClient: &http.Client{}}
+	_, err := client.Verify()
+	if err != nil {
+		t.Errorf("Should not have received an error, got: %s", err)
+	}
+}

--- a/incapsula/provider.go
+++ b/incapsula/provider.go
@@ -95,6 +95,7 @@ func Provider() *schema.Provider {
 			"incapsula_security_rule_exception":  resourceSecurityRuleException(),
 			"incapsula_site":                     resourceSite(),
 			"incapsula_waf_security_rule":        resourceWAFSecurityRule(),
+			"incapsula_account":                  resourceAccount(),
 		},
 	}
 

--- a/incapsula/resource_account.go
+++ b/incapsula/resource_account.go
@@ -1,0 +1,319 @@
+package incapsula
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func resourceAccount() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAccountCreate,
+		Read:   resourceAccountRead,
+		Update: resourceAccountUpdate,
+		Delete: resourceAccountDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			// Required Arguments
+			"email": {
+				Description: "Email address. For example: joe@example.com.",
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
+					d := val.(string)
+					parts := strings.Split(d, "@")
+					if len(parts) == 2 {
+						errs = append(errs, fmt.Errorf("%q must be an email address (joe@example.com), got: %s", key, d))
+					}
+					return
+				},
+			},
+
+			// Optional Arguments
+			"parent_id": {
+				Description: "The newly created account's parent id. If not specified, the invoking account will be assigned as the parent.",
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Computed:    true,
+			},
+			"ref_id": {
+				Description: "Customer specific identifier for this operation.",
+				Type:        schema.TypeString,
+				Optional:    true,
+			},
+			"user_name": {
+				Description: "The account owner's name. For example: John Doe.",
+				Type:        schema.TypeString,
+				Optional:    true,
+			},
+			"plan_id": {
+				Description: "An identifier of the plan to assign to the new account. For example, ent100 for the Enterprise 100 plan.",
+				Type:        schema.TypeString,
+				Optional:    true,
+			},
+			"account_name": {
+				Description: "Account name.",
+				Type:        schema.TypeString,
+				Optional:    true,
+			},
+			"logs_account_id": {
+				Description: "Available only for Enterprise Plan customers that purchased the Logs Integration SKU. Numeric identifier of the account that purchased the logs integration SKU and which collects the logs. If not specified, operation will be performed on the account identified by the authentication parameters.",
+				Type:        schema.TypeString,
+				Optional:    true,
+			},
+			"log_level": {
+				Description:  "The log level. Options are `full`, `security`, and `none`. Defaults to `none`.",
+				Type:         schema.TypeString,
+				Default:      "none",
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"full", "security", "none"}, false),
+			},
+			"error_page_template": {
+				Description: "Base64 encoded template for an error page.",
+				Type:        schema.TypeString,
+				Optional:    true,
+			},
+			"support_all_tls_versions": {
+				Description: "Allow sites in the account to support all TLS versions for connectivity between clients (visitors) and the Imperva service.",
+				Type:        schema.TypeString,
+				Optional:    true,
+			},
+			"naked_domain_san_for_new_www_sites": {
+				Description:  "Add naked domain SAN to Incapsula SSL certificates for new www sites. Options are `true` and `false`. Defaults to `true`",
+				Type:         schema.TypeString,
+				Default:      "true",
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false", "default"}, false),
+			},
+			"wildcard_san_for_new_sites": {
+				Description:  "Add wildcard SAN to Incapsula SSL certificates for new sites. Options are `true`, `false` and `default`. Defaults to `default`",
+				Type:         schema.TypeString,
+				Default:      "default",
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false", "default"}, false),
+			},
+			"data_storage_region": {
+				Description:  "Default data region of the account for newly created sites. Options are `APAC`, `EU`, `US` and `DEFAULT`. Defaults to `DEFAULT`.",
+				Type:         schema.TypeString,
+				Default:      "DEFAULT",
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"APAC", "EU", "US", "DEFAULT"}, false),
+			},
+
+			// Computed Attributes
+			"support_level": {
+				Description: "Account support level",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"plan_name": {
+				Description: "Name of plan associate with account",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"trial_end_date": {
+				Description: "End date for trial account",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func resourceAccountCreate(d *schema.ResourceData, m interface{}) error {
+	client := m.(*Client)
+	email := d.Get("email").(string)
+
+	log.Printf("[INFO] Creating Incapsula account for email: %s\n", email)
+
+	accountAddResponse, err := client.AddAccount(
+		email,
+		d.Get("ref_id").(string),
+		d.Get("user_name").(string),
+		d.Get("plan_id").(string),
+		d.Get("account_name").(string),
+		d.Get("log_level").(string),
+		d.Get("logs_account_id").(int),
+		d.Get("parent_id").(int),
+	)
+
+	if err != nil {
+		log.Printf("[ERROR] Could not create Incapsula account for email: %s, %s\n", email, err)
+		return err
+	}
+
+	// Set the Account ID
+	d.SetId(strconv.Itoa(accountAddResponse.Account.AccountID))
+	log.Printf("[INFO] Created Incapsula account for email: %s\n", email)
+
+	// There may be a timing/race condition here
+	// Set an arbitrary period to sleep
+	time.Sleep(3 * time.Second)
+
+	err = updateAdditionalAccountProperties(client, d)
+	if err != nil {
+		return err
+	}
+
+	err = updateDefaultDataStorageRegion(client, d)
+	if err != nil {
+		return err
+	}
+
+	// Set the rest of the state from the resource read
+	return resourceAccountRead(d, m)
+}
+
+func resourceAccountRead(d *schema.ResourceData, m interface{}) error {
+	client := m.(*Client)
+
+	accountID, _ := strconv.Atoi(d.Id())
+
+	log.Printf("[INFO] Reading Incapsula account for Account ID: %d\n", accountID)
+
+	accountStatusResponse, err := client.AccountStatus(accountID)
+
+	// Account object may have been deleted
+	if accountStatusResponse != nil && accountStatusResponse.Res.(float64) == 9403 {
+		log.Printf("[INFO] Incapsula Account ID %d has already been deleted: %s\n", accountID, err)
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		log.Printf("[ERROR] Could not read Incapsula account for Account ID: %d, %s\n", accountID, err)
+		return err
+	}
+
+	d.Set("parent_id", accountStatusResponse.Account.ParentID)
+	d.Set("email", accountStatusResponse.Account.Email)
+	d.Set("plan_id", accountStatusResponse.Account.PlanID)
+	d.Set("plan_name", accountStatusResponse.Account.PlanName)
+	d.Set("trial_end_date", accountStatusResponse.Account.TrialEndDate)
+	d.Set("account_id", accountStatusResponse.Account.AccountID)
+	d.Set("ref_id", accountStatusResponse.Account.RefID)
+	d.Set("user_name", accountStatusResponse.Account.UserName)
+	d.Set("account_name", accountStatusResponse.Account.AccountName)
+	d.Set("support_levels", accountStatusResponse.Account.SupportLevel)
+	d.Set("support_all_tls_versions", accountStatusResponse.Account.SupportAllTLSVersions)
+	d.Set("wildcard_san_for_new_sites", accountStatusResponse.Account.WildcardSANForNewSites)
+	d.Set("naked_domain_san_for_new_www_sites", accountStatusResponse.Account.NakedDomainSANForNewWWWSites)
+
+	// Get the performance settings for the site
+	defaultAccountDataStorageRegion, err := client.GetAccountDataStorageRegion(d.Id())
+	if err != nil {
+		log.Printf("[ERROR] Could not read Incapsula default data storage region for account id: %d, %s\n", accountID, err)
+		return err
+	}
+	d.Set("data_storage_region", defaultAccountDataStorageRegion.Region)
+
+	log.Printf("[INFO] Finished reading Incapsula account for account ud: %d\n", accountID)
+
+	return nil
+}
+
+func resourceAccountUpdate(d *schema.ResourceData, m interface{}) error {
+	client := m.(*Client)
+
+	updateParams := [3]string{"email ", "plan_id", "ref_id"}
+	for i := 0; i < len(updateParams); i++ {
+		param := updateParams[i]
+		if d.HasChange(param) && d.Get(param) != "" {
+			log.Printf("[INFO] Updating Incapsula account param (%s) with value (%s) for account_id: %s\n", param, d.Get(param).(string), d.Id())
+			_, err := client.UpdateAccount(d.Id(), param, d.Get(param).(string))
+			if err != nil {
+				log.Printf("[ERROR] Could not update Incapsula account param (%s) with value (%s) for account_id: %s %s\n", param, d.Get(param).(string), d.Id(), err)
+				return err
+			}
+		}
+	}
+
+	err := updateAdditionalAccountProperties(client, d)
+	if err != nil {
+		return err
+	}
+
+	err = updateAccountLogLevel(client, d)
+	if err != nil {
+		return err
+	}
+
+	err = updateDefaultDataStorageRegion(client, d)
+	if err != nil {
+		return err
+	}
+
+	// Set the rest of the state from the resource read
+	return resourceAccountRead(d, m)
+}
+
+func resourceAccountDelete(d *schema.ResourceData, m interface{}) error {
+	client := m.(*Client)
+	accountID, _ := strconv.Atoi(d.Id())
+
+	log.Printf("[INFO] Deleting Incapsula account id: %d\n", accountID)
+
+	err := client.DeleteAccount(accountID)
+
+	if err != nil {
+		log.Printf("[ERROR] Could not delete Incapsula account id: %d, %s\n", accountID, err)
+		return err
+	}
+
+	// Set the ID to empty
+	// Implicitly clears the resource
+	d.SetId("")
+
+	log.Printf("[INFO] Deleted Incapsula account id: %d\n", accountID)
+
+	return nil
+}
+
+func updateAdditionalAccountProperties(client *Client, d *schema.ResourceData) error {
+	updateParams := [5]string{"name", "error_page_template", "support_all_tls_versions", "naked_domain_san_for_new_www_sites", "wildcard_san_for_new_sites"}
+	for i := 0; i < len(updateParams); i++ {
+		param := updateParams[i]
+		if d.HasChange(param) && d.Get(param) != "" {
+			log.Printf("[INFO] Updating Incapsula account param (%s) with value (%s) for account_id: %s\n", param, d.Get(param).(string), d.Id())
+			_, err := client.UpdateAccount(d.Id(), param, d.Get(param).(string))
+			if err != nil {
+				log.Printf("[ERROR] Could not update Incapsula account param (%s) with value (%s) for account_id: %s %s\n", param, d.Get(param).(string), d.Id(), err)
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func updateAccountLogLevel(client *Client, d *schema.ResourceData) error {
+	if d.HasChange("log_level") {
+		logLevel := d.Get("log_level").(string)
+		err := client.UpdateLogLevel(d.Id(), logLevel)
+		if err != nil {
+			log.Printf("[ERROR] Could not update Incapsula account log level: %s for account_id: %s %s\n", logLevel, d.Id(), err)
+			return err
+		}
+	}
+	return nil
+}
+
+func updateDefaultDataStorageRegion(client *Client, d *schema.ResourceData) error {
+	if d.HasChange("data_storage_region") {
+		region := d.Get("data_storage_region").(string)
+		_, err := client.UpdateAccountDataStorageRegion(d.Id(), region)
+		if err != nil {
+			log.Printf("[ERROR] Could not update Incapsula account default data storage region: %s for account_id: %s %s\n", region, d.Id(), err)
+			return err
+		}
+	}
+	return nil
+}

--- a/incapsula/resource_account_test.go
+++ b/incapsula/resource_account_test.go
@@ -1,0 +1,112 @@
+package incapsula
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+const testEmail = "example@example.com"
+const accountResourceName = "incapsula_account.test-terraform-account"
+
+func TestIncapsulaAccount_Basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckIncapsulaAccountDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testCheckIncapsulaAccountConfigBasic(testEmail),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckIncapsulaAccountExists(accountResourceName),
+					resource.TestCheckResourceAttr(accountResourceName, "email", testEmail),
+				),
+			},
+		},
+	})
+}
+
+func TestIncapsulaAccount_ImportBasic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckIncapsulaAccountDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testCheckIncapsulaAccountConfigBasic(testEmail),
+			},
+			{
+				ResourceName:      "incapsula_account.test-terraform-account",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testCheckIncapsulaAccountDestroy(state *terraform.State) error {
+	client := testAccProvider.Meta().(*Client)
+
+	for _, res := range state.RootModule().Resources {
+		if res.Type != "incapsula_account" {
+			continue
+		}
+
+		accountIDStr := res.Primary.ID
+		if accountIDStr == "" {
+			return fmt.Errorf("Incapsula account ID does not exist")
+		}
+
+		accountID, err := strconv.Atoi(accountIDStr)
+		if err != nil {
+			return fmt.Errorf("Account ID conversion error for %s: %s", accountIDStr, err)
+		}
+
+		_, err = client.AccountStatus(accountID)
+
+		if err == nil {
+			return fmt.Errorf("Incapsula account id: %d still exists", accountID)
+		}
+	}
+
+	return nil
+}
+
+func testCheckIncapsulaAccountExists(name string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		res, ok := state.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Incapsula account resource not found: %s", name)
+		}
+
+		accountIDStr := res.Primary.ID
+		if accountIDStr == "" {
+			return fmt.Errorf("Incapsula account ID does not exist")
+		}
+
+		accountID, err := strconv.Atoi(accountIDStr)
+		if err != nil {
+			return fmt.Errorf("Account ID conversion error for %s: %s", accountIDStr, err)
+		}
+
+		client := testAccProvider.Meta().(*Client)
+		accountStatusResponse, err := client.AccountStatus(accountID)
+		if accountStatusResponse == nil {
+			return fmt.Errorf("Incapsula account id: %d does not exist", accountID)
+		}
+
+		return nil
+	}
+}
+
+func testCheckIncapsulaAccountConfigBasic(email string) string {
+	return fmt.Sprintf(`
+		resource "incapsula_account" "test-terraform-account" {
+			email = "%s"
+		}`,
+		email,
+	)
+}

--- a/website/docs/r/account.html.markdown
+++ b/website/docs/r/account.html.markdown
@@ -1,0 +1,62 @@
+---
+layout: "incapsula"
+page_title: "Incapsula: account"
+sidebar_current: "docs-incapsula-resource-account"
+description: |-
+  Provides a Incapsula Account resource.
+---
+
+# incapsula_site
+
+Provides a Incapsula Account resource. 
+Accounts are the core resource that is required by site resources.
+
+## Example Usage
+
+```hcl
+resource "incapsula_account" "example-account" {
+  email                              = "example@example.com"
+  parent_id                          = 123
+  ref_id                             = "123"
+  user_name                          = "John Doe"
+  plan_id                            = "ent100"
+  account_name                       = "Example Account"
+  logs_account_id                    = "456"
+  log_level                          = "full"
+
+  data_storage_region                = "US"
+  support_all_tls_versions           = true
+  naked_domain_san_for_new_www_sites = true
+  wildcard_san_for_new_sites         = "default"
+
+  # Base64 Encoded HTML
+  error_page_template                = "RlP5QhsBHAECGUVDFxYZVCQFBwkDBggLBA0MFB0cGhsYFTgCIgUgJx3EG8LuM6ZpqwR8ScEztVwTqbxuB8..."
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `email` - (Required) Email address. For example: joe@example.com.
+* `parent_id` - (Optional) The newly created account's parent id. If not specified, the invoking account will be assigned as the parent.
+* `ref_id` - (Optional) Customer specific identifier for this operation.
+* `user_name` - (Optional) The account owner's name. For example: John Doe.
+* `plan_id` - (Optional) An identifier of the plan to assign to the new account. For example, ent100 for the Enterprise 100 plan.
+* `account_name` - (Optional) Account name.
+* `logs_account_id` - (Optional) Account where logs should be stored. Available only for Enterprise Plan customers that purchased the Logs Integration SKU. Numeric identifier of the account that purchased the logs integration SKU and which collects the logs. If not specified, operation will be performed on the account identified by the authentication parameters.
+* `log_level` - (Optional) The log level. Options are `full`, `security`, and `none`. Defaults to `none`.
+* `data_storage_region` - (Optional) Default data region of the account for newly created sites. Options are `APAC`, `EU`, `US` and `DEFAULT`. Defaults to `DEFAULT`.
+* `support_all_tls_versions` - (Optional) Allow sites in the account to support all TLS versions for connectivity between clients (visitors) and the Imperva service.
+* `naked_domain_san_for_new_www_sites` - (Optional) Add naked domain SAN to Incapsula SSL certificates for new www sites. Options are `true` and `false`. Defaults to `true`.
+* `wildcard_san_for_new_sites` - (Optional) Add wildcard SAN to Incapsula SSL certificates for new sites. Options are `true`, `false` and `default`. Defaults to `default`.
+* `error_page_template` - (Optional) Base64 encoded template for an error page.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - Unique identifier in the API for the site.
+* `trial_end_date` - Numeric representation of the site creation date.
+* `support_level` - The CNAME record name.
+* `plan_name` - The CNAME record value.

--- a/website/incapsula.erb
+++ b/website/incapsula.erb
@@ -43,6 +43,9 @@
             <li<%= sidebar_current("docs-incapsula-resource-waf-security-rule") %>>
               <a href="/docs/providers/incapsula/r/waf_security_rule.html">incapsula_waf_security_rule</a>
             </li>
+            <li<%= sidebar_current("docs-incapsula-resource-account") %>>
+              <a href="/docs/providers/incapsula/r/account.html">incapsula_account</a>
+            </li>
           </ul>
         </li>
       </ul>


### PR DESCRIPTION
Changes included in this Pull Request:
 - Migrate "Client" settings to `client.go` and `client_test.go`
 - Add new Resource `resource_account.go`
 - Add new Client `client_account.go`
 - Add new Client `client_account_data_storage_region.go`
 - Added tests for Resource and Clients