### PR TITLE
resource_origin_pop - implementing read and import for the resource. …

### DIFF
--- a/incapsula/client_data_center.go
+++ b/incapsula/client_data_center.go
@@ -35,6 +35,7 @@ type DataCenterListResponse struct {
 		Name        string `json:"name"`
 		ContentOnly string `json:"contentOnly"`
 		IsActive    string `json:"isActive"`
+		OriginPop   string `json:"originPop"`
 	} `json:"DCs"`
 }
 

--- a/incapsula/client_incap_rule.go
+++ b/incapsula/client_incap_rule.go
@@ -11,20 +11,25 @@ import (
 
 // IncapRule is a struct that encompasses all the properties of an IncapRule
 type IncapRule struct {
-	Name                string `json:"name"`
-	Action              string `json:"action"`
-	Filter              string `json:"filter,omitempty"`
-	ResponseCode        int    `json:"response_code,omitempty"`
-	AddMissing          bool   `json:"add_missing,omitempty"`
-	From                string `json:"from,omitempty"`
-	To                  string `json:"to,omitempty"`
-	RewriteName         string `json:"rewrite_name,omitempty"`
-	DCID                int    `json:"dc_id,omitempty"`
-	RateContext         string `json:"rate_context,omitempty"`
-	RateInterval        int    `json:"rate_interval,omitempty"`
-	ErrorType           string `json:"error_type,omitempty"`
-	ErrorResponseFormat string `json:"error_response_format,omitempty"`
-	ErrorResponseData   string `json:"error_response_data,omitempty"`
+	Name                  string `json:"name"`
+	Action                string `json:"action"`
+	Filter                string `json:"filter,omitempty"`
+	ResponseCode          int    `json:"response_code,omitempty"`
+	AddMissing            bool   `json:"add_missing,omitempty"`
+	From                  string `json:"from,omitempty"`
+	To                    string `json:"to,omitempty"`
+	RewriteName           string `json:"rewrite_name,omitempty"`
+	DCID                  int    `json:"dc_id,omitempty"`
+	PortForwardingContext string `json:"port_forwarding_context,omitempty"`
+	PortForwardingValue   string `json:"port_forwarding_value,omitempty"`
+	RateContext           string `json:"rate_context,omitempty"`
+	RateInterval          int    `json:"rate_interval,omitempty"`
+	ErrorType             string `json:"error_type,omitempty"`
+	ErrorResponseFormat   string `json:"error_response_format,omitempty"`
+	ErrorResponseData     string `json:"error_response_data,omitempty"`
+	MultipleDeletions     bool   `json:"multiple_deletions,omitempty"`
+	OverrideWafRule       string `json:"overrideWafRule,omitempty"`
+	OverrideWafAction     string `json:"overrideWafAction,omitempty"`
 }
 
 // IncapRuleWithID contains the IncapRule as well as the rule identifier

--- a/incapsula/client_origin_pop.go
+++ b/incapsula/client_origin_pop.go
@@ -19,10 +19,17 @@ type SetOriginPOPResponse struct {
 
 // SetOriginPOP sets the origin POP for given data center
 func (c *Client) SetOriginPOP(dcID int, originPOP string) error {
+	originPopModifyUrl := ""
+	if originPOP != "" {
+		originPopModifyUrl = fmt.Sprintf("%s/sites/datacenter/origin-pop/modify?api_id=%s&api_key=%s&origin_pop=%s&dc_id=%d", c.config.BaseURL, c.config.APIID, c.config.APIKey, originPOP, dcID)
+	} else { // setting the origin pop to NONE is done by not sending the origin_pop query param
+		originPopModifyUrl = fmt.Sprintf("%s/sites/datacenter/origin-pop/modify?api_id=%s&api_key=%s&dc_id=%d", c.config.BaseURL, c.config.APIID, c.config.APIKey, dcID)
+	}
+
 	// Post request to Incapsula
 	req, err := http.NewRequest(
 		http.MethodPost,
-		fmt.Sprintf("%s/sites/datacenter/origin-pop/modify?api_id=%s&api_key=%s&origin_pop=%s&dc_id=%d", c.config.BaseURL, c.config.APIID, c.config.APIKey, originPOP, dcID),
+		originPopModifyUrl,
 		nil)
 	if err != nil {
 		return fmt.Errorf("Error preparing HTTP POST for setting Incapsula origin POP: %s for data center: %d: %s", originPOP, dcID, err)

--- a/incapsula/resource_origin_pop.go
+++ b/incapsula/resource_origin_pop.go
@@ -2,21 +2,21 @@ package incapsula
 
 import (
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"log"
 	"strconv"
 	"strings"
-	"time"
-
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceOriginPOP() *schema.Resource {
 	return &schema.Resource{
-		Create:   resourceOriginPOPUpdate,
-		Read:     resourceOriginPOPRead,
-		Update:   resourceOriginPOPUpdate,
-		Delete:   resourceOriginPOPDelete,
-		Importer: nil,
+		Create: resourceOriginPOPUpdate,
+		Read:   resourceOriginPOPRead,
+		Update: resourceOriginPOPUpdate,
+		Delete: resourceOriginPOPDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 
 		Schema: map[string]*schema.Schema{
 			// Required Arguments
@@ -25,6 +25,11 @@ func resourceOriginPOP() *schema.Resource {
 				Type:        schema.TypeInt,
 				Required:    true,
 				ForceNew:    true,
+			},
+			"site_id": {
+				Description: "Numeric identifier of the site.",
+				Type:        schema.TypeInt,
+				Required:    true,
 			},
 			"origin_pop": {
 				Description: "The Origin POP code (must be lowercase), e.g: iad. Note, this field is create/update only. Reads are not supported as the API doesn't exist yet. Note that drift may happen.",
@@ -46,6 +51,7 @@ func resourceOriginPOP() *schema.Resource {
 func resourceOriginPOPUpdate(d *schema.ResourceData, m interface{}) error {
 	client := m.(*Client)
 	dcID := d.Get("dc_id").(int)
+	siteID := d.Get("site_id").(int)
 	originPOP := d.Get("origin_pop").(string)
 
 	log.Printf("[INFO] Setting Incapsula origin POP: %s for data center: %d\n", originPOP, dcID)
@@ -57,17 +63,64 @@ func resourceOriginPOPUpdate(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 
-	// Set the ID
-	d.SetId(strconv.FormatInt(time.Now().Unix(), 10))
 	log.Printf("[INFO] Set Incapsula origin POP: %s for data center: %d\n", originPOP, dcID)
 
-	return nil
+	syntheticID := fmt.Sprintf("%d/%d", siteID, dcID)
+	d.SetId(syntheticID)
+
+	return resourceOriginPOPRead(d, m)
 }
 
 func resourceOriginPOPRead(d *schema.ResourceData, m interface{}) error {
+	// Implement by reading the ListDataCentersResponse for the data centers
+	client := m.(*Client)
+	siteID := strings.Split(d.Id(), "/")[0]
+	dcID := strings.Split(d.Id(), "/")[1]
+
+	listDataCentersResponse, err := client.ListDataCenters(siteID)
+
+	if err != nil {
+		log.Printf("[ERROR] Could not read origin POP for data center: %s, site: %s %s\n", dcID, siteID, err)
+		return err
+	}
+
+	found := false
+
+	for _, dataCenter := range listDataCentersResponse.DCs {
+		if dataCenter.ID == dcID {
+			originPop := dataCenter.OriginPop
+			if originPop != "" {
+				siteIDInteger, _ := strconv.Atoi(siteID)
+				dcIDInteger, _ := strconv.Atoi(dcID)
+				d.Set("site_id", siteIDInteger)
+				d.Set("dc_id", dcIDInteger)
+				d.Set("origin_pop", originPop)
+				syntheticID := fmt.Sprintf("%s/%s", siteID, dcID)
+				d.SetId(syntheticID)
+				found = true
+				break
+			}
+		}
+	}
+
+	if !found {
+		d.SetId("")
+	}
+
 	return nil
 }
 
 func resourceOriginPOPDelete(d *schema.ResourceData, m interface{}) error {
+	client := m.(*Client)
+	dcID := d.Get("dc_id").(int)
+	err := client.SetOriginPOP(dcID, "")
+
+	if err != nil {
+		log.Printf("[ERROR] Could not delete Incapsula origin POP for data center: %d: %s\n", dcID, err)
+		return err
+	}
+
+	log.Printf("[INFO] Deleted Incapsula origin POP for data center: %d\n", dcID)
+
 	return nil
 }

--- a/website/docs/r/incap_rule.html.markdown
+++ b/website/docs/r/incap_rule.html.markdown
@@ -140,7 +140,7 @@ The following arguments are supported:
 
 * `site_id` - (Required) Numeric identifier of the site to operate on.
 * `name` - (Required) Rule name.
-* `action` - (Required) Rule action. See the detailed descriptions in the API documentation. Possible values: `RULE_ACTION_REDIRECT`, `RULE_ACTION_SIMPLIFIED_REDIRECT`, `RULE_ACTION_REWRITE_URL`, `RULE_ACTION_REWRITE_HEADER`, `RULE_ACTION_REWRITE_COOKIE`, `RULE_ACTION_DELETE_HEADER`, `RULE_ACTION_DELETE_COOKIE`, `RULE_ACTION_RESPONSE_REWRITE_HEADER`, `RULE_ACTION_RESPONSE_DELETE_HEADER`, `RULE_ACTION_RESPONSE_REWRITE_RESPONSE_CODE`, `RULE_ACTION_FORWARD_TO_DC`, `RULE_ACTION_ALERT`, `RULE_ACTION_BLOCK`, `RULE_ACTION_BLOCK_USER`, `RULE_ACTION_BLOCK_IP`, `RULE_ACTION_RETRY`, `RULE_ACTION_INTRUSIVE_HTML`, `RULE_ACTION_CAPTCHA`, `RULE_ACTION_RATE`, `RULE_ACTION_CUSTOM_ERROR_RESPONSE`.
+* `action` - (Required) Rule action. See the detailed descriptions in the API documentation. Possible values: `RULE_ACTION_REDIRECT`, `RULE_ACTION_SIMPLIFIED_REDIRECT`, `RULE_ACTION_REWRITE_URL`, `RULE_ACTION_REWRITE_HEADER`, `RULE_ACTION_REWRITE_COOKIE`, `RULE_ACTION_DELETE_HEADER`, `RULE_ACTION_DELETE_COOKIE`, `RULE_ACTION_RESPONSE_REWRITE_HEADER`, `RULE_ACTION_RESPONSE_DELETE_HEADER`, `RULE_ACTION_RESPONSE_REWRITE_RESPONSE_CODE`, `RULE_ACTION_FORWARD_TO_DC`, `RULE_ACTION_ALERT`, `RULE_ACTION_BLOCK`, `RULE_ACTION_BLOCK_USER`, `RULE_ACTION_BLOCK_IP`, `RULE_ACTION_RETRY`, `RULE_ACTION_INTRUSIVE_HTML`, `RULE_ACTION_CAPTCHA`, `RULE_ACTION_RATE`, `RULE_ACTION_CUSTOM_ERROR_RESPONSE`, `RULE_ACTION_FORWARD_TO_PORT`.
 * `filter` - (Required) The filter defines the conditions that trigger the rule action. For action `RULE_ACTION_SIMPLIFIED_REDIRECT` filter is not relevant. For other actions, if left empty, the rule is always run.
 * `response_code` - (Optional) For `RULE_ACTION_REDIRECT` or `RULE_ACTION_SIMPLIFIED_REDIRECT` rule's response code, valid values are `302`, `301`, `303`, `307`, `308`. For `RULE_ACTION_RESPONSE_REWRITE_RESPONSE_CODE` rule's response code, valid values are all 3-digits numbers. For `RULE_ACTION_CUSTOM_ERROR_RESPONSE`, valid values are `400`, `401`, `402`, `403`, `404`, `405`, `406`, `407`, `408`, `409`, `410`, `411`, `412`, `413`, `414`, `415`, `416`, `417`, `419`, `420`, `422`, `423`, `424`, `500`, `501`, `502`, `503`, `504`, `505`, `507`.
 * `add_missing` - (Optional) Add cookie or header if it doesn't exist (Rewrite cookie rule only).
@@ -148,11 +148,16 @@ The following arguments are supported:
 * `to` - (Optional) Pattern to change to. `RULE_ACTION_REWRITE_URL` - Url to change to. `RULE_ACTION_REWRITE_HEADER` and `RULE_ACTION_RESPONSE_REWRITE_HEADER` - Header value to change to. `RULE_ACTION_REWRITE_COOKIE` - Cookie value to change to.
 * `rewrite_name` - (Optional) Name of cookie or header to rewrite. Applies only for `RULE_ACTION_REWRITE_COOKIE`, `RULE_ACTION_REWRITE_HEADER` and `RULE_ACTION_RESPONSE_REWRITE_HEADER`.
 * `dc_id` - (Optional) Data center to forward request to. Applies only for `RULE_ACTION_FORWARD_TO_DC`.
+* `port_forwarding_context` - (Optional) Context for port forwarding. \"Use Port Value\" or \"Use Header Name\". Applies only for `RULE_ACTION_FORWARD_TO_PORT`.
+* `port_forwarding_value` - (Optional) Port number or header name for port forwarding. Applies only for `RULE_ACTION_FORWARD_TO_PORT`.
 * `rate_context` - (Optional) The context of the rate counter. Possible values `IP` or `Session`. Applies only to rules using `RULE_ACTION_RATE`.
 * `rate_interval` - (Optional) The interval in seconds of the rate counter. Possible values is a multiple of `10`; minimum `10` and maximum `300`. Applies only to rules using `RULE_ACTION_RATE`.
 * `error_type` - (Optional) The error that triggers the rule. `error.type.all` triggers the rule regardless of the error type. Applies only for `RULE_ACTION_CUSTOM_ERROR_RESPONSE`. Possible values: `error.type.all`, `error.type.connection_timeout`, `error.type.access_denied`, `error.type.parse_req_error`, `error.type.parse_resp_error`, `error.type.connection_failed`, `error.type.deny_and_retry`, `error.type.ssl_failed`, `error.type.deny_and_captcha`, `error.type.2fa_required`, `error.type.no_ssl_config`, `error.type.no_ipv6_config`.
 * `error_response_format` - (Optional) The format of the given error response in the error_response_data field. Applies only for `RULE_ACTION_CUSTOM_ERROR_RESPONSE`. Possible values: `json`, `xml`.
 * `error_response_data` - (Optional) The response returned when the request matches the filter and is blocked. Applies only for `RULE_ACTION_CUSTOM_ERROR_RESPONSE`.
+* `multiple_deletions` - (Optional) Delete multiple header occurrences. Applies only to rules using `RULE_ACTION_DELETE_HEADER` and `RULE_ACTION_RESPONSE_DELETE_HEADER`.
+* `overrideWafAction` - (Optional) The response returned when the request matches the filter and is blocked. Applies only for `RULE_ACTION_CUSTOM_ERROR_RESPONSE`.
+* `overrideWafRule` - (Optional) The action for the override rule. Possible values: Alert Only, Block Request, Block User, Block IP, Ignore.
 
 ## Attributes Reference
 
@@ -162,8 +167,8 @@ The following attributes are exported:
 
 ## Import
 
-Incap Rule can be imported using the `id`, e.g.:
+Incap Rule can be imported using the role site_id and rule_id separated by /, e.g.:
 
 ```
-$ terraform import incapsula_incap_rule.demo 1234
+$ terraform import incapsula_incap_rule.demo site_id/rule_id
 ```

--- a/website/docs/r/origin_pop.html.markdown
+++ b/website/docs/r/origin_pop.html.markdown
@@ -42,4 +42,8 @@ The following attributes are exported:
 
 ## Import
 
-terraform import incapsula_origin_pop.aws-east site_id/dc_id
+Origin Pop can be imported using the `site_id` and `dc_id` separated by /, e.g.:
+
+```
+$ terraform import incapsula_origin_pop.aws-east site_id/dc_id
+```

--- a/website/docs/r/origin_pop.html.markdown
+++ b/website/docs/r/origin_pop.html.markdown
@@ -22,6 +22,7 @@ resource "incapsula_data_center" "example-data-center" {
 
 resource "incapsula_origin_pop" "aws-east" {
   dc_id = incapsula_data_center.example-data-center.id
+  site_id = incapsula_site.example-site.id
   origin_pop = "iad"
 }
 ```
@@ -41,4 +42,4 @@ The following attributes are exported:
 
 ## Import
 
-Origin POP cannot be imported.
+terraform import incapsula_origin_pop.aws-east site_id/dc_id


### PR DESCRIPTION
…Read and import are using the list dcs API which starting 06/06/21 will return the originPop as part of its response. NOTICE: there is an additional parameter "site_id" required in the origin pop configuration file. The request for setting originPop to NONE requires sending no value in the request, that's why in the function setOriginPop the URL is constructed by the case. (modify vs "delete")