### PR TITLE
Fix redundant edit data center server when enabled = false

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -531,6 +531,7 @@ golang.org/x/sys v0.0.0-20200523222454-059865788121 h1:rITEj+UZHYC927n8GT97eC3zr
 golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210324051608-47abb6519492 h1:Paq34FxTluEPvVyayQqMPgHm+vTOrIifmcYxFBx9TLg=
 golang.org/x/sys v0.0.0-20210324051608-47abb6519492/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/incapsula/client_data_center_server.go
+++ b/incapsula/client_data_center_server.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/url"
+	"strconv"
 )
 
 // Endpoints (unexported consts)
@@ -26,8 +27,13 @@ type DataCenterServerEditResponse struct {
 }
 
 // AddDataCenterServer adds an incap data center server to be managed by Incapsula
-func (c *Client) AddDataCenterServer(dcID, serverAddress, isStandby string) (*DataCenterServerAddResponse, error) {
+func (c *Client) AddDataCenterServer(dcID, serverAddress, isStandby string, isEnabled string) (*DataCenterServerAddResponse, error) {
 	log.Printf("[INFO] Adding Incapsula data center server for dcID: %s\n", dcID)
+
+	bIsEnabled, err := strconv.ParseBool(isEnabled)
+	if err != nil {
+		return nil, fmt.Errorf("Error from Incapsula service when adding data center server for dcID %s: %s", dcID, err)
+	}
 
 	// Post form to Incapsula
 	resp, err := c.httpClient.PostForm(fmt.Sprintf("%s/%s", c.config.BaseURL, endpointDataCenterServerAdd), url.Values{
@@ -36,6 +42,7 @@ func (c *Client) AddDataCenterServer(dcID, serverAddress, isStandby string) (*Da
 		"dc_id":          {dcID},
 		"server_address": {serverAddress},
 		"is_standby":     {isStandby},
+		"is_disabled":    {strconv.FormatBool(!bIsEnabled)},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("Error from Incapsula service when adding data center server for dcID %s: %s", dcID, err)

--- a/incapsula/client_data_center_server_test.go
+++ b/incapsula/client_data_center_server_test.go
@@ -17,7 +17,7 @@ func TestClientAddDataCenterServerBadConnection(t *testing.T) {
 	config := &Config{APIID: "foo", APIKey: "bar", BaseURL: "badness.incapsula.com"}
 	client := &Client{config: config, httpClient: &http.Client{Timeout: time.Millisecond * 1}}
 	dcID := "42"
-	addDataCenterServerResponse, err := client.AddDataCenterServer(dcID, "", "")
+	addDataCenterServerResponse, err := client.AddDataCenterServer(dcID, "", "", "true")
 	if err == nil {
 		t.Errorf("Should have received an error")
 	}
@@ -41,7 +41,7 @@ func TestClientAddDataCenterServerBadJSON(t *testing.T) {
 	config := &Config{APIID: "foo", APIKey: "bar", BaseURL: server.URL}
 	client := &Client{config: config, httpClient: &http.Client{}}
 	dcID := "42"
-	addDataCenterServerResponse, err := client.AddDataCenterServer(dcID, "", "")
+	addDataCenterServerResponse, err := client.AddDataCenterServer(dcID, "", "", "false")
 	if err == nil {
 		t.Errorf("Should have received an error")
 	}
@@ -65,7 +65,7 @@ func TestClientAddDataCenterServerInvalidRule(t *testing.T) {
 	config := &Config{APIID: "foo", APIKey: "bar", BaseURL: server.URL}
 	client := &Client{config: config, httpClient: &http.Client{}}
 	dcID := "42"
-	addDataCenterServerResponse, err := client.AddDataCenterServer(dcID, "", "")
+	addDataCenterServerResponse, err := client.AddDataCenterServer(dcID, "", "", "true")
 	if err == nil {
 		t.Errorf("Should have received an error")
 	}
@@ -89,7 +89,7 @@ func TestClientAddDataCenterServerValidRule(t *testing.T) {
 	config := &Config{APIID: "foo", APIKey: "bar", BaseURL: server.URL}
 	client := &Client{config: config, httpClient: &http.Client{}}
 	dcID := "42"
-	addDataCenterServerResponse, err := client.AddDataCenterServer(dcID, "", "")
+	addDataCenterServerResponse, err := client.AddDataCenterServer(dcID, "", "", "false")
 	if err != nil {
 		t.Errorf("Should not have received an error")
 	}

--- a/incapsula/resource_data_center_server.go
+++ b/incapsula/resource_data_center_server.go
@@ -76,19 +76,11 @@ func resourceDataCenterServerCreate(d *schema.ResourceData, m interface{}) error
 		d.Get("dc_id").(string),
 		d.Get("server_address").(string),
 		d.Get("is_standby").(string),
+		d.Get("is_enabled").(string),
 	)
 
 	if err != nil {
 		return err
-	}
-
-	if d.Get("is_enabled") != "" {
-		log.Printf("[INFO] Updating data center server server_id (%s) with is_enabled (%s)\n", dataCenterServerAddResponse.ServerID, d.Get("is_enabled").(string))
-		_, err := client.EditDataCenterServer(dataCenterServerAddResponse.ServerID, d.Get("server_address").(string), d.Get("is_standby").(string), d.Get("is_enabled").(string))
-		if err != nil {
-			log.Printf("[ERROR] Could not update data center server server_id (%s) with is_enabled (%s) %s\n", dataCenterServerAddResponse.ServerID, d.Get("is_enabled").(string), err)
-			return err
-		}
 	}
 
 	// Set the server ID


### PR DESCRIPTION
edit server endpoint has is_enabled parameter
add server endpoint has is_deleted parameter, which should be used