### PR TITLE
Policy asset association

### DIFF
--- a/incapsula/client_policy_asset_association_test.go
+++ b/incapsula/client_policy_asset_association_test.go
@@ -1,0 +1,60 @@
+package incapsula
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestClientPolicyAssetAssociatedPositive(t *testing.T) {
+	isAssociated, err := ClientPolicyAssetAssociatedBase(t, true)
+	if err != nil {
+		t.Errorf("unexpected error")
+	}
+	if !isAssociated {
+		t.Errorf("expected policy to be assosiated")
+	}
+}
+
+func TestClientPolicyAssetAssociatedNegative(t *testing.T) {
+	isAssociated, err := ClientPolicyAssetAssociatedBase(t, false)
+	if err == nil {
+		t.Errorf("epected error but got none")
+	}
+	if isAssociated {
+		t.Errorf("expected policy to NOT be assosiated")
+	}
+}
+
+func ClientPolicyAssetAssociatedBase(t *testing.T, shouldBeAssociated bool) (bool, error) {
+	log.Printf("======================== BEGIN TEST ========================")
+	log.Printf("[DEBUG] Running test Running test client_policy_asset_association.TestClientPolicyAssetAssociated, shouldBeAssociated set to %t", shouldBeAssociated)
+	apiID := "foo"
+	apiKey := "bar"
+	assetID := "5432"
+	policyID := "11"
+	assetType := "WEBSITE"
+
+	endpoint := fmt.Sprintf("/policies/v2/policies/%s/assets/%s/%s?api_id=%s&api_key=%s", policyID, assetType, assetID, apiID, apiKey)
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if req.URL.String() != endpoint {
+			t.Errorf("Should have have hit %s endpoint. Got: %s", endpoint, req.URL.String())
+		}
+		if shouldBeAssociated {
+			rw.WriteHeader(200)
+			rw.Write([]byte(`{"value":true,"isError":false}`))
+		} else {
+			rw.WriteHeader(404)
+			rw.Write([]byte(`{"value":false,"isError":false}`))
+		}
+	}))
+	defer server.Close()
+
+	config := &Config{APIID: apiID, APIKey: apiKey, BaseURLAPI: server.URL}
+	client := &Client{config: config, httpClient: &http.Client{}}
+
+	return client.isPolicyAssetAssociated(policyID, assetID, assetType)
+
+}

--- a/incapsula/resource_policy_asset_association.go
+++ b/incapsula/resource_policy_asset_association.go
@@ -80,7 +80,7 @@ func resourcePolicyAssetAssociationRead(d *schema.ResourceData, m interface{}) e
 
 	if isAssociated {
 		log.Printf("[INFO] Successfully read Policy Asset Association exist: %s-%s-%s\n", policyID, assetID, assetType)
-		syntheticID := fmt.Sprintf("%s-%s-%s", policyID, assetID, assetType)
+		syntheticID := fmt.Sprintf("%s/%s/%s", policyID, assetID, assetType)
 
 		d.Set("asset_id", assetID)
 		d.Set("asset_type", assetType)

--- a/incapsula/resource_policy_asset_association.go
+++ b/incapsula/resource_policy_asset_association.go
@@ -56,7 +56,7 @@ func resourcePolicyAssetAssociationCreate(d *schema.ResourceData, m interface{})
 	}
 
 	// Generate synthetic ID
-	syntheticID := fmt.Sprintf("%s-%s-%s", policyID, assetID, assetType)
+	syntheticID := fmt.Sprintf("%s/%s/%s", policyID, assetID, assetType)
 	d.SetId(syntheticID)
 	log.Printf("[INFO] Created Incapsula policy asset association with ID: %s - policy ID (%s) - asset ID (%s) - asset type (%s)\n", syntheticID, policyID, assetID, assetType)
 

--- a/website/docs/r/policy_asset_association.html.markdown
+++ b/website/docs/r/policy_asset_association.html.markdown
@@ -36,4 +36,9 @@ The following attributes are exported:
 
 ## Import
 
-terraform import incapsula_policy_asset_association.example-policy-asset-association policy_id/asset_id/asset_type
+Policy can be imported using the `policy_id`, `asset_id` and `asset_type` e.g.:
+
+```
+$ terraform import incapsula_policy_asset_association.example-policy-asset-association policy_id/asset_id/asset_type
+```
+

--- a/website/docs/r/policy_asset_association.html.markdown
+++ b/website/docs/r/policy_asset_association.html.markdown
@@ -36,4 +36,4 @@ The following attributes are exported:
 
 ## Import
 
-Policy Asset Association cannot be imported.
+terraform import incapsula_policy_asset_association.example-policy-asset-association policy_id/asset_id/asset_type


### PR DESCRIPTION
This is replacing
https://github.com/imperva/terraform-provider-incapsula/pull/77

include the same code + unit tests for the new functionality 
no component tests - we do not actively create and delete association through this resource, the associations are created when working with the asset (site) and the policy resources. 