### PR TITLE
Provider version header

### DIFF
--- a/incapsula/client_account.go
+++ b/incapsula/client_account.go
@@ -90,8 +90,6 @@ func (c *Client) AddAccount(email, refID, userName, planID, accountName, logLeve
 	log.Printf("[INFO] Adding Incapsula account for email: %s (account ID %d)\n", email, parentID)
 
 	values := url.Values{
-		"api_id":       {c.config.APIID},
-		"api_key":      {c.config.APIKey},
 		"email":        {email},
 		"user_name":    {userName},
 		"plan_id":      {planID},
@@ -109,7 +107,8 @@ func (c *Client) AddAccount(email, refID, userName, planID, accountName, logLeve
 		values["logs_account_id"][0] = fmt.Sprint(logsAccountID)
 	}
 
-	resp, err := c.httpClient.PostForm(fmt.Sprintf("%s/%s", c.config.BaseURL, endpointAccountAdd), values)
+	reqURL := fmt.Sprintf("%s/%s", c.config.BaseURL, endpointAccountAdd)
+	resp, err := c.PostFormWithHeaders(reqURL, values)
 	if err != nil {
 		return nil, fmt.Errorf("Error adding account for email %s: %s", email, err)
 	}
@@ -141,11 +140,9 @@ func (c *Client) AccountStatus(accountID int) (*AccountStatusResponse, error) {
 	log.Printf("[INFO] Getting Incapsula account status for account id: %d\n", accountID)
 
 	// Post form to Incapsula
-	resp, err := c.httpClient.PostForm(fmt.Sprintf("%s/%s", c.config.BaseURL, endpointAccountStatus), url.Values{
-		"api_id":     {c.config.APIID},
-		"api_key":    {c.config.APIKey},
-		"account_id": {strconv.Itoa(accountID)},
-	})
+	values := url.Values{"account_id": {strconv.Itoa(accountID)}}
+	reqURL := fmt.Sprintf("%s/%s", c.config.BaseURL, endpointAccountStatus)
+	resp, err := c.PostFormWithHeaders(reqURL, values)
 	if err != nil {
 		return nil, fmt.Errorf("Error getting account status for account id %d: %s", accountID, err)
 	}
@@ -184,14 +181,13 @@ func (c *Client) AccountStatus(accountID int) (*AccountStatusResponse, error) {
 func (c *Client) UpdateAccount(accountID, param, value string) (*AccountUpdateResponse, error) {
 	log.Printf("[INFO] Updating Incapsula account for accountID: %s\n", accountID)
 
-	// Post form to Incapsula
-	resp, err := c.httpClient.PostForm(fmt.Sprintf("%s/%s", c.config.BaseURL, endpointAccountUpdate), url.Values{
-		"api_id":     {c.config.APIID},
-		"api_key":    {c.config.APIKey},
+	values := url.Values{
 		"account_id": {accountID},
 		"param":      {param},
 		"value":      {value},
-	})
+	}
+	reqURL := fmt.Sprintf("%s/%s", c.config.BaseURL, endpointAccountUpdate)
+	resp, err := c.PostFormWithHeaders(reqURL, values)
 	if err != nil {
 		return nil, fmt.Errorf("Error updating param (%s) with value (%s) on account_id: %s: %s", param, value, accountID, err)
 	}
@@ -230,11 +226,9 @@ func (c *Client) DeleteAccount(accountID int) error {
 	log.Printf("[INFO] Deleting Incapsula account id: %d\n", accountID)
 
 	// Post form to Incapsula
-	resp, err := c.httpClient.PostForm(fmt.Sprintf("%s/%s", c.config.BaseURL, endpointAccountDelete), url.Values{
-		"api_id":     {c.config.APIID},
-		"api_key":    {c.config.APIKey},
-		"account_id": {strconv.Itoa(accountID)},
-	})
+	values := url.Values{"account_id": {strconv.Itoa(accountID)}}
+	reqURL := fmt.Sprintf("%s/%s", c.config.BaseURL, endpointAccountDelete)
+	resp, err := c.PostFormWithHeaders(reqURL, values)
 	if err != nil {
 		return fmt.Errorf("Error deleting account id: %d: %s", accountID, err)
 	}

--- a/incapsula/client_account_data_storage_region.go
+++ b/incapsula/client_account_data_storage_region.go
@@ -26,11 +26,9 @@ func (c *Client) GetAccountDataStorageRegion(accountID string) (*AccountDataStor
 	log.Printf("[INFO] Getting default Incapsula data storage region for account: %s\n", accountID)
 
 	// Post form to Incapsula
-	resp, err := c.httpClient.PostForm(fmt.Sprintf("%s/%s", c.config.BaseURL, endpointAccountDataStorageRegionGet), url.Values{
-		"api_id":     {c.config.APIID},
-		"api_key":    {c.config.APIKey},
-		"account_id": {accountID},
-	})
+	values := url.Values{"account_id": {accountID}}
+	reqURL := fmt.Sprintf("%s/%s", c.config.BaseURL, endpointAccountDataStorageRegionGet)
+	resp, err := c.PostFormWithHeaders(reqURL, values)
 	if err != nil {
 		return nil, fmt.Errorf("Error getting default data storage region for account id: %s: %s", accountID, err)
 	}
@@ -62,12 +60,12 @@ func (c *Client) UpdateAccountDataStorageRegion(accountID, region string) (*Acco
 	log.Printf("[INFO] Updating Incapsula default data storage region (%s) for accountID: %s\n", region, accountID)
 
 	// Post form to Incapsula
-	resp, err := c.httpClient.PostForm(fmt.Sprintf("%s/%s", c.config.BaseURL, endpointAccountDataStorageRegionUpdate), url.Values{
-		"api_id":              {c.config.APIID},
-		"api_key":             {c.config.APIKey},
+	values := url.Values{
 		"account_id":          {accountID},
 		"data_storage_region": {region},
-	})
+	}
+	reqURL := fmt.Sprintf("%s/%s", c.config.BaseURL, endpointAccountDataStorageRegionUpdate)
+	resp, err := c.PostFormWithHeaders(reqURL, values)
 	if err != nil {
 		return nil, fmt.Errorf("Error updating data storage region with value (%s) on account_id: %s: %s", region, accountID, err)
 	}

--- a/incapsula/client_cache_rule.go
+++ b/incapsula/client_cache_rule.go
@@ -1,7 +1,6 @@
 package incapsula
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -40,10 +39,8 @@ func (c *Client) AddCacheRule(siteID string, rule *CacheRule) (*CacheRuleWithID,
 	log.Printf("[DEBUG] Incapsula Add Cache Rule JSON request body: %s\n", string(ruleJSON))
 
 	// Post form to Incapsula
-	resp, err := c.httpClient.Post(
-		fmt.Sprintf("%s/sites/%s/settings/cache/rules?api_id=%s&api_key=%s", c.config.BaseURLRev2, siteID, c.config.APIID, c.config.APIKey),
-		"application/json",
-		bytes.NewReader(ruleJSON))
+	reqURL := fmt.Sprintf("%s/sites/%s/settings/cache/rules", c.config.BaseURLRev2, siteID)
+	resp, err := c.DoJsonRequestWithHeaders(http.MethodPost, reqURL, ruleJSON)
 	if err != nil {
 		return nil, fmt.Errorf("Error from Incapsula service when adding Cache Rule for Site ID %s: %s", siteID, err)
 	}
@@ -75,7 +72,8 @@ func (c *Client) ReadCacheRule(siteID string, ruleID int) (*CacheRuleWithID, int
 	log.Printf("[INFO] Getting Incapsula Cache Rule %d for Site ID %s\n", ruleID, siteID)
 
 	// Post form to Incapsula
-	resp, err := c.httpClient.Get(fmt.Sprintf("%s/sites/%s/settings/cache/rules/%d?api_id=%s&api_key=%s", c.config.BaseURLRev2, siteID, ruleID, c.config.APIID, c.config.APIKey))
+	reqURL := fmt.Sprintf("%s/sites/%s/settings/cache/rules/%d", c.config.BaseURLRev2, siteID, ruleID)
+	resp, err := c.DoJsonRequestWithHeaders(http.MethodGet, reqURL, nil)
 	if err != nil {
 		return nil, 0, fmt.Errorf("Error from Incapsula service when reading Cache Rule %d for Site ID %s: %s", ruleID, siteID, err)
 	}
@@ -112,14 +110,8 @@ func (c *Client) UpdateCacheRule(siteID string, ruleID int, rule *CacheRule) err
 	}
 
 	// Put request to Incapsula
-	req, err := http.NewRequest(
-		http.MethodPut,
-		fmt.Sprintf("%s/sites/%s/settings/cache/rules/%d?api_id=%s&api_key=%s", c.config.BaseURLRev2, siteID, ruleID, c.config.APIID, c.config.APIKey),
-		bytes.NewReader(ruleJSON))
-	if err != nil {
-		return fmt.Errorf("Error preparing HTTP PUT for updating Cache Rule %d for Site ID %s: %s", ruleID, siteID, err)
-	}
-	resp, err := c.httpClient.Do(req)
+	reqURL := fmt.Sprintf("%s/sites/%s/settings/cache/rules/%d", c.config.BaseURLRev2, siteID, ruleID)
+	resp, err := c.DoJsonRequestWithHeaders(http.MethodPut, reqURL, ruleJSON)
 	if err != nil {
 		return fmt.Errorf("Error from Incapsula service when updating Cache Rule %d for Site ID %s: %s", ruleID, siteID, err)
 	}
@@ -160,14 +152,8 @@ func (c *Client) DeleteCacheRule(siteID string, ruleID int) error {
 	log.Printf("[INFO] Deleting Incapsula Cache Rule %d for Site ID %s\n", ruleID, siteID)
 
 	// Delete request to Incapsula
-	req, err := http.NewRequest(
-		http.MethodDelete,
-		fmt.Sprintf("%s/sites/%s/settings/cache/rules/%d?api_id=%s&api_key=%s", c.config.BaseURLRev2, siteID, ruleID, c.config.APIID, c.config.APIKey),
-		nil)
-	if err != nil {
-		return fmt.Errorf("Error preparing HTTP DELETE for deleting Cache Rule %d for Site ID %s: %s", ruleID, siteID, err)
-	}
-	resp, err := c.httpClient.Do(req)
+	reqURL := fmt.Sprintf("%s/sites/%s/settings/cache/rules/%d", c.config.BaseURLRev2, siteID, ruleID)
+	resp, err := c.DoJsonRequestWithHeaders(http.MethodDelete, reqURL, nil)
 	if err != nil {
 		return fmt.Errorf("Error from Incapsula service when deleting Cache Rule %d for Site ID %s: %s", ruleID, siteID, err)
 	}

--- a/incapsula/client_cache_rule_test.go
+++ b/incapsula/client_cache_rule_test.go
@@ -42,7 +42,7 @@ func TestClientAddCacheRuleBadJSON(t *testing.T) {
 	apiKey := "bar"
 	siteID := "42"
 
-	endpoint := fmt.Sprintf("/sites/%s/settings/cache/rules?api_id=%s&api_key=%s", siteID, apiID, apiKey)
+	endpoint := fmt.Sprintf("/sites/%s/settings/cache/rules", siteID)
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		if req.URL.String() != endpoint {
@@ -79,7 +79,7 @@ func TestClientAddCacheRuleInvalidRule(t *testing.T) {
 	apiKey := "bar"
 	siteID := "42"
 
-	endpoint := fmt.Sprintf("/sites/%s/settings/cache/rules?api_id=%s&api_key=%s", siteID, apiID, apiKey)
+	endpoint := fmt.Sprintf("/sites/%s/settings/cache/rules", siteID)
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(406)
@@ -114,7 +114,7 @@ func TestClientAddCacheRuleValidRule(t *testing.T) {
 	apiKey := "bar"
 	siteID := "42"
 
-	endpoint := fmt.Sprintf("/sites/%s/settings/cache/rules?api_id=%s&api_key=%s", siteID, apiID, apiKey)
+	endpoint := fmt.Sprintf("/sites/%s/settings/cache/rules", siteID)
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(200)
@@ -175,7 +175,7 @@ func TestClientReadCacheRuleBadJSON(t *testing.T) {
 	siteID := "42"
 	ruleID := 62
 
-	endpoint := fmt.Sprintf("/sites/%s/settings/cache/rules/%d?api_id=%s&api_key=%s", siteID, ruleID, apiID, apiKey)
+	endpoint := fmt.Sprintf("/sites/%s/settings/cache/rules/%d", siteID, ruleID)
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		if req.URL.String() != endpoint {
@@ -206,7 +206,7 @@ func TestClientReadCacheRuleInvalidRule(t *testing.T) {
 	siteID := "42"
 	ruleID := 29010333
 
-	endpoint := fmt.Sprintf("/sites/%s/settings/cache/rules/%d?api_id=%s&api_key=%s", siteID, ruleID, apiID, apiKey)
+	endpoint := fmt.Sprintf("/sites/%s/settings/cache/rules/%d", siteID, ruleID)
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(404)
@@ -241,7 +241,7 @@ func TestClientReadCacheRuleValidRule(t *testing.T) {
 	siteID := "42"
 	ruleID := 66772
 
-	endpoint := fmt.Sprintf("/sites/%s/settings/cache/rules/%d?api_id=%s&api_key=%s", siteID, ruleID, apiID, apiKey)
+	endpoint := fmt.Sprintf("/sites/%s/settings/cache/rules/%d", siteID, ruleID)
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(200)
@@ -309,7 +309,7 @@ func TestClientUpdateCacheRuleBadJSON(t *testing.T) {
 		Enabled: true,
 	}
 
-	endpoint := fmt.Sprintf("/sites/%s/settings/cache/rules/%d?api_id=%s&api_key=%s", siteID, ruleID, apiID, apiKey)
+	endpoint := fmt.Sprintf("/sites/%s/settings/cache/rules/%d", siteID, ruleID)
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		if req.URL.String() != endpoint {
@@ -344,7 +344,7 @@ func TestClientUpdateCacheRuleInvalidRule(t *testing.T) {
 		Enabled: true,
 	}
 
-	endpoint := fmt.Sprintf("/sites/%s/settings/cache/rules/%d?api_id=%s&api_key=%s", siteID, ruleID, apiID, apiKey)
+	endpoint := fmt.Sprintf("/sites/%s/settings/cache/rules/%d", siteID, ruleID)
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(404)
@@ -380,7 +380,7 @@ func TestClientUpdateCacheRuleValidRule(t *testing.T) {
 		Enabled: true,
 	}
 
-	endpoint := fmt.Sprintf("/sites/%s/settings/cache/rules/%d?api_id=%s&api_key=%s", siteID, ruleID, apiID, apiKey)
+	endpoint := fmt.Sprintf("/sites/%s/settings/cache/rules/%d", siteID, ruleID)
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(200)
@@ -425,7 +425,7 @@ func TestClientDeleteCacheRuleInvalidRule(t *testing.T) {
 	siteID := "42"
 	ruleID := 11111
 
-	endpoint := fmt.Sprintf("/sites/%s/settings/cache/rules/%d?api_id=%s&api_key=%s", siteID, ruleID, apiID, apiKey)
+	endpoint := fmt.Sprintf("/sites/%s/settings/cache/rules/%d", siteID, ruleID)
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(200)
@@ -454,7 +454,7 @@ func TestClientDeleteCacheRuleValidRule(t *testing.T) {
 	siteID := "42"
 	ruleID := 290109
 
-	endpoint := fmt.Sprintf("/sites/%s/settings/cache/rules/%d?api_id=%s&api_key=%s", siteID, ruleID, apiID, apiKey)
+	endpoint := fmt.Sprintf("/sites/%s/settings/cache/rules/%d", siteID, ruleID)
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(200)

--- a/incapsula/client_certificate.go
+++ b/incapsula/client_certificate.go
@@ -45,8 +45,6 @@ func (c *Client) AddCertificate(siteID, certificate, privateKey, passphrase stri
 	log.Printf("[INFO] Adding custom certificate for site_id: %s", siteID)
 
 	values := url.Values{
-		"api_id":      {c.config.APIID},
-		"api_key":     {c.config.APIKey},
 		"site_id":     {siteID},
 		"certificate": {certificate},
 	}
@@ -60,7 +58,8 @@ func (c *Client) AddCertificate(siteID, certificate, privateKey, passphrase stri
 	}
 
 	// Post to Incapsula
-	resp, err := c.httpClient.PostForm(fmt.Sprintf("%s/%s", c.config.BaseURL, endpointCertificateAdd), values)
+	reqURL := fmt.Sprintf("%s/%s", c.config.BaseURL, endpointCertificateAdd)
+	resp, err := c.PostFormWithHeaders(reqURL, values)
 	if err != nil {
 		return nil, fmt.Errorf("Error from Incapsula service when adding custom certificate for site_id %s: %s", siteID, err)
 	}
@@ -92,11 +91,9 @@ func (c *Client) ListCertificates(siteID string) (*CertificateListResponse, erro
 	log.Printf("[INFO] Getting Incapsula site custom certificates (site_id: %s)\n", siteID)
 
 	// Post form to Incapsula
-	resp, err := c.httpClient.PostForm(fmt.Sprintf("%s/%s", c.config.BaseURL, endpointCertificateList), url.Values{
-		"api_id":  {c.config.APIID},
-		"api_key": {c.config.APIKey},
-		"site_id": {siteID},
-	})
+	values := url.Values{"site_id": {siteID}}
+	reqURL := fmt.Sprintf("%s/%s", c.config.BaseURL, endpointCertificateList)
+	resp, err := c.PostFormWithHeaders(reqURL, values)
 	if err != nil {
 		return nil, fmt.Errorf("Error getting custom certificates for site_id %s: %s", siteID, err)
 	}
@@ -130,8 +127,6 @@ func (c *Client) EditCertificate(siteID, certificate, privateKey, passphrase str
 	log.Printf("[INFO] Editing custom certificate for Incapsula site_id: %s\n", siteID)
 
 	values := url.Values{
-		"api_id":      {c.config.APIID},
-		"api_key":     {c.config.APIKey},
 		"site_id":     {siteID},
 		"certificate": {b64Certificate},
 	}
@@ -145,7 +140,8 @@ func (c *Client) EditCertificate(siteID, certificate, privateKey, passphrase str
 	}
 
 	// Post to Incapsula
-	resp, err := c.httpClient.PostForm(fmt.Sprintf("%s/%s", c.config.BaseURL, endpointCertificateEdit), values)
+	reqURL := fmt.Sprintf("%s/%s", c.config.BaseURL, endpointCertificateEdit)
+	resp, err := c.PostFormWithHeaders(reqURL, values)
 	if err != nil {
 		return nil, fmt.Errorf("Error editing custom certificate for site_id: %s: %s", siteID, err)
 	}
@@ -184,11 +180,9 @@ func (c *Client) DeleteCertificate(siteID string) error {
 	log.Printf("[INFO] Deleting Incapsula custom certificate for site_id: %s\n", siteID)
 
 	// Post form to Incapsula
-	resp, err := c.httpClient.PostForm(fmt.Sprintf("%s/%s", c.config.BaseURL, endpointCertificateDelete), url.Values{
-		"api_id":  {c.config.APIID},
-		"api_key": {c.config.APIKey},
-		"site_id": {siteID},
-	})
+	values := url.Values{"site_id": {siteID}}
+	reqURL := fmt.Sprintf("%s/%s", c.config.BaseURL, endpointCertificateDelete)
+	resp, err := c.PostFormWithHeaders(reqURL, values)
 	if err != nil {
 		return fmt.Errorf("Error deleting custom certificate for site_id: %s %s", siteID, err)
 	}

--- a/incapsula/client_data_center.go
+++ b/incapsula/client_data_center.go
@@ -50,15 +50,15 @@ func (c *Client) AddDataCenter(siteID, name, serverAddress, isContent, isEnabled
 	log.Printf("[INFO] Adding Incapsula data center for siteID: %s\n", siteID)
 
 	// Post form to Incapsula
-	resp, err := c.httpClient.PostForm(fmt.Sprintf("%s/%s", c.config.BaseURL, endpointDataCenterAdd), url.Values{
-		"api_id":         {c.config.APIID},
-		"api_key":        {c.config.APIKey},
+	values := url.Values{
 		"site_id":        {siteID},
 		"name":           {name},
 		"server_address": {serverAddress},
 		"is_content":     {isContent},
 		"is_enabled":     {isEnabled},
-	})
+	}
+	reqURL := fmt.Sprintf("%s/%s", c.config.BaseURL, endpointDataCenterAdd)
+	resp, err := c.PostFormWithHeaders(reqURL, values)
 	if err != nil {
 		return nil, fmt.Errorf("Error from Incapsula service when adding data center for siteID %s: %s", siteID, err)
 	}
@@ -100,11 +100,9 @@ func (c *Client) ListDataCenters(siteID string) (*DataCenterListResponse, error)
 	log.Printf("[INFO] Getting Incapsula data centers (site_id: %s)\n", siteID)
 
 	// Post form to Incapsula
-	resp, err := c.httpClient.PostForm(fmt.Sprintf("%s/%s", c.config.BaseURL, endpointDataCenterList), url.Values{
-		"api_id":  {c.config.APIID},
-		"api_key": {c.config.APIKey},
-		"site_id": {siteID},
-	})
+	values := url.Values{"site_id": {siteID}}
+	reqURL := fmt.Sprintf("%s/%s", c.config.BaseURL, endpointDataCenterList)
+	resp, err := c.PostFormWithHeaders(reqURL, values)
 	if err != nil {
 		return nil, fmt.Errorf("Error getting data centers for siteID %s: %s", siteID, err)
 	}
@@ -146,9 +144,7 @@ func (c *Client) EditDataCenter(dcID, name, isContent, isEnabled string) (*DataC
 	log.Printf("[INFO] Editing Incapsula data center for dcID: %s\n", dcID)
 
 	values := url.Values{
-		"api_id":  {c.config.APIID},
-		"api_key": {c.config.APIKey},
-		"dc_id":   {dcID},
+		"dc_id": {dcID},
 	}
 
 	if name != "" {
@@ -164,7 +160,8 @@ func (c *Client) EditDataCenter(dcID, name, isContent, isEnabled string) (*DataC
 	}
 
 	// Post form to Incapsula
-	resp, err := c.httpClient.PostForm(fmt.Sprintf("%s/%s", c.config.BaseURL, endpointDataCenterEdit), values)
+	reqURL := fmt.Sprintf("%s/%s", c.config.BaseURL, endpointDataCenterEdit)
+	resp, err := c.PostFormWithHeaders(reqURL, values)
 	if err != nil {
 		return nil, fmt.Errorf("Error editing data center (%s): %s", dcID, err)
 	}
@@ -217,11 +214,9 @@ func (c *Client) DeleteDataCenter(dcID string) error {
 	log.Printf("[INFO] Deleting Incapsula data center id: %s\n", dcID)
 
 	// Post form to Incapsula
-	resp, err := c.httpClient.PostForm(fmt.Sprintf("%s/%s", c.config.BaseURL, endpointDataCenterDelete), url.Values{
-		"api_id":  {c.config.APIID},
-		"api_key": {c.config.APIKey},
-		"dc_id":   {dcID},
-	})
+	values := url.Values{"dc_id": {dcID}}
+	reqURL := fmt.Sprintf("%s/%s", c.config.BaseURL, endpointDataCenterDelete)
+	resp, err := c.PostFormWithHeaders(reqURL, values)
 	if err != nil {
 		return fmt.Errorf("Error deleting data center (%s): %s", dcID, err)
 	}

--- a/incapsula/client_data_center_server.go
+++ b/incapsula/client_data_center_server.go
@@ -36,14 +36,14 @@ func (c *Client) AddDataCenterServer(dcID, serverAddress, isStandby string, isEn
 	}
 
 	// Post form to Incapsula
-	resp, err := c.httpClient.PostForm(fmt.Sprintf("%s/%s", c.config.BaseURL, endpointDataCenterServerAdd), url.Values{
-		"api_id":         {c.config.APIID},
-		"api_key":        {c.config.APIKey},
+	values := url.Values{
 		"dc_id":          {dcID},
 		"server_address": {serverAddress},
 		"is_standby":     {isStandby},
 		"is_disabled":    {strconv.FormatBool(!bIsEnabled)},
-	})
+	}
+	reqURL := fmt.Sprintf("%s/%s", c.config.BaseURL, endpointDataCenterServerAdd)
+	resp, err := c.PostFormWithHeaders(reqURL, values)
 	if err != nil {
 		return nil, fmt.Errorf("Error from Incapsula service when adding data center server for dcID %s: %s", dcID, err)
 	}
@@ -85,14 +85,14 @@ func (c *Client) EditDataCenterServer(serverID, serverAddress, isStandby, isEnab
 	log.Printf("[INFO] Editing Incapsula data center server for serverID: %s\n", serverID)
 
 	// Post form to Incapsula
-	resp, err := c.httpClient.PostForm(fmt.Sprintf("%s/%s", c.config.BaseURL, endpointDataCenterServerEdit), url.Values{
-		"api_id":         {c.config.APIID},
-		"api_key":        {c.config.APIKey},
+	values := url.Values{
 		"server_id":      {serverID},
 		"server_address": {serverAddress},
 		"is_standby":     {isStandby},
 		"is_enabled":     {isEnabled},
-	})
+	}
+	reqURL := fmt.Sprintf("%s/%s", c.config.BaseURL, endpointDataCenterServerEdit)
+	resp, err := c.PostFormWithHeaders(reqURL, values)
 	if err != nil {
 		return nil, fmt.Errorf("Error editing data center server for serverID: %s: %s", serverID, err)
 	}
@@ -141,11 +141,9 @@ func (c *Client) DeleteDataCenterServer(serverID string) error {
 	log.Printf("[INFO] Deleting Incapsula data center server ID: %s\n", serverID)
 
 	// Post form to Incapsula
-	resp, err := c.httpClient.PostForm(fmt.Sprintf("%s/%s", c.config.BaseURL, endpointDataCenterServerDelete), url.Values{
-		"api_id":    {c.config.APIID},
-		"api_key":   {c.config.APIKey},
-		"server_id": {serverID},
-	})
+	values := url.Values{"server_id": {serverID}}
+	reqURL := fmt.Sprintf("%s/%s", c.config.BaseURL, endpointDataCenterServerDelete)
+	resp, err := c.PostFormWithHeaders(reqURL, values)
 	if err != nil {
 		return fmt.Errorf("Error deleting data center server (server_id: %s): %s", serverID, err)
 	}

--- a/incapsula/client_data_storage_region.go
+++ b/incapsula/client_data_storage_region.go
@@ -26,11 +26,9 @@ func (c *Client) GetDataStorageRegion(siteID string) (*DataStorageRegionResponse
 	log.Printf("[INFO] Getting Incapsula data storage region for site: %s\n", siteID)
 
 	// Post form to Incapsula
-	resp, err := c.httpClient.PostForm(fmt.Sprintf("%s/%s", c.config.BaseURL, endpointDataStorageRegionGet), url.Values{
-		"api_id":  {c.config.APIID},
-		"api_key": {c.config.APIKey},
-		"site_id": {siteID},
-	})
+	values := url.Values{"site_id": {siteID}}
+	reqURL := fmt.Sprintf("%s/%s", c.config.BaseURL, endpointDataStorageRegionGet)
+	resp, err := c.PostFormWithHeaders(reqURL, values)
 	if err != nil {
 		return nil, fmt.Errorf("Error getting data storage region for site id: %s: %s", siteID, err)
 	}
@@ -62,12 +60,12 @@ func (c *Client) UpdateDataStorageRegion(siteID, region string) (*DataStorageReg
 	log.Printf("[INFO] Updating Incapsula site data storage region (%s) for siteID: %s\n", region, siteID)
 
 	// Post form to Incapsula
-	resp, err := c.httpClient.PostForm(fmt.Sprintf("%s/%s", c.config.BaseURL, endpointDataStorageRegionUpdate), url.Values{
-		"api_id":              {c.config.APIID},
-		"api_key":             {c.config.APIKey},
+	values := url.Values{
 		"site_id":             {siteID},
 		"data_storage_region": {region},
-	})
+	}
+	reqURL := fmt.Sprintf("%s/%s", c.config.BaseURL, endpointDataStorageRegionUpdate)
+	resp, err := c.PostFormWithHeaders(reqURL, values)
 	if err != nil {
 		return nil, fmt.Errorf("Error updating data storage region with value (%s) on site_id: %s: %s", region, siteID, err)
 	}

--- a/incapsula/client_incap_rule.go
+++ b/incapsula/client_incap_rule.go
@@ -1,7 +1,6 @@
 package incapsula
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -48,10 +47,8 @@ func (c *Client) AddIncapRule(siteID string, rule *IncapRule) (*IncapRuleWithID,
 	}
 
 	// Post form to Incapsula
-	resp, err := c.httpClient.Post(
-		fmt.Sprintf("%s/sites/%s/rules?api_id=%s&api_key=%s", c.config.BaseURLRev2, siteID, c.config.APIID, c.config.APIKey),
-		"application/json",
-		bytes.NewReader(ruleJSON))
+	reqURL := fmt.Sprintf("%s/sites/%s/rules", c.config.BaseURLRev2, siteID)
+	resp, err := c.DoJsonRequestWithHeaders(http.MethodPost, reqURL, ruleJSON)
 	if err != nil {
 		return nil, fmt.Errorf("Error from Incapsula service when adding Incap Rule for Site ID %s: %s", siteID, err)
 	}
@@ -83,7 +80,8 @@ func (c *Client) ReadIncapRule(siteID string, ruleID int) (*IncapRuleWithID, int
 	log.Printf("[INFO] Getting Incapsula Incap Rule %d for Site ID %s\n", ruleID, siteID)
 
 	// Post form to Incapsula
-	resp, err := c.httpClient.Get(fmt.Sprintf("%s/sites/%s/rules/%d?api_id=%s&api_key=%s", c.config.BaseURLRev2, siteID, ruleID, c.config.APIID, c.config.APIKey))
+	reqURL := fmt.Sprintf("%s/sites/%s/rules/%d", c.config.BaseURLRev2, siteID, ruleID)
+	resp, err := c.DoJsonRequestWithHeaders(http.MethodGet, reqURL, nil)
 	if err != nil {
 		return nil, 0, fmt.Errorf("Error from Incapsula service when reading Incap Rule %d for Site ID %s: %s", ruleID, siteID, err)
 	}
@@ -120,14 +118,8 @@ func (c *Client) UpdateIncapRule(siteID string, ruleID int, rule *IncapRule) (*I
 	}
 
 	// Put request to Incapsula
-	req, err := http.NewRequest(
-		http.MethodPut,
-		fmt.Sprintf("%s/sites/%s/rules/%d?api_id=%s&api_key=%s", c.config.BaseURLRev2, siteID, ruleID, c.config.APIID, c.config.APIKey),
-		bytes.NewReader(ruleJSON))
-	if err != nil {
-		return nil, fmt.Errorf("Error preparing HTTP PUT for updating Incap Rule %d for Site ID %s: %s", ruleID, siteID, err)
-	}
-	resp, err := c.httpClient.Do(req)
+	reqURL := fmt.Sprintf("%s/sites/%s/rules/%d", c.config.BaseURLRev2, siteID, ruleID)
+	resp, err := c.DoJsonRequestWithHeaders(http.MethodPut, reqURL, ruleJSON)
 	if err != nil {
 		return nil, fmt.Errorf("Error from Incapsula service when updating Incap Rule %d for Site ID %s: %s", ruleID, siteID, err)
 	}
@@ -159,14 +151,8 @@ func (c *Client) DeleteIncapRule(siteID string, ruleID int) error {
 	log.Printf("[INFO] Deleting Incapsula Incap Rule %d for Site ID %s\n", ruleID, siteID)
 
 	// Delete request to Incapsula
-	req, err := http.NewRequest(
-		http.MethodDelete,
-		fmt.Sprintf("%s/sites/%s/rules/%d?api_id=%s&api_key=%s", c.config.BaseURLRev2, siteID, ruleID, c.config.APIID, c.config.APIKey),
-		nil)
-	if err != nil {
-		return fmt.Errorf("Error preparing HTTP DELETE for deleting Incap Rule %d for Site ID %s: %s", ruleID, siteID, err)
-	}
-	resp, err := c.httpClient.Do(req)
+	reqURL := fmt.Sprintf("%s/sites/%s/rules/%d", c.config.BaseURLRev2, siteID, ruleID)
+	resp, err := c.DoJsonRequestWithHeaders(http.MethodDelete, reqURL, nil)
 	if err != nil {
 		return fmt.Errorf("Error from Incapsula service when deleting Incap Rule %d for Site ID %s: %s", ruleID, siteID, err)
 	}

--- a/incapsula/client_incap_rule_test.go
+++ b/incapsula/client_incap_rule_test.go
@@ -41,7 +41,7 @@ func TestClientAddIncapRuleBadJSON(t *testing.T) {
 	apiKey := "bar"
 	siteID := "42"
 
-	endpoint := fmt.Sprintf("/sites/%s/rules?api_id=%s&api_key=%s", siteID, apiID, apiKey)
+	endpoint := fmt.Sprintf("/sites/%s/rules", siteID)
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		if req.URL.String() != endpoint {
@@ -77,7 +77,7 @@ func TestClientAddIncapRuleInvalidRule(t *testing.T) {
 	apiKey := "bar"
 	siteID := "42"
 
-	endpoint := fmt.Sprintf("/sites/%s/rules?api_id=%s&api_key=%s", siteID, apiID, apiKey)
+	endpoint := fmt.Sprintf("/sites/%s/rules", siteID)
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(406)
@@ -112,7 +112,7 @@ func TestClientAddIncapRuleValidRule(t *testing.T) {
 	apiKey := "bar"
 	siteID := "42"
 
-	endpoint := fmt.Sprintf("/sites/%s/rules?api_id=%s&api_key=%s", siteID, apiID, apiKey)
+	endpoint := fmt.Sprintf("/sites/%s/rules", siteID)
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(200)
@@ -172,7 +172,7 @@ func TestClientReadIncapRuleBadJSON(t *testing.T) {
 	siteID := "42"
 	ruleID := 62
 
-	endpoint := fmt.Sprintf("/sites/%s/rules/%d?api_id=%s&api_key=%s", siteID, ruleID, apiID, apiKey)
+	endpoint := fmt.Sprintf("/sites/%s/rules/%d", siteID, ruleID)
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		if req.URL.String() != endpoint {
@@ -203,7 +203,7 @@ func TestClientReadIncapRuleInvalidRule(t *testing.T) {
 	siteID := "42"
 	ruleID := 29010333
 
-	endpoint := fmt.Sprintf("/sites/%s/rules/%d?api_id=%s&api_key=%s", siteID, ruleID, apiID, apiKey)
+	endpoint := fmt.Sprintf("/sites/%s/rules/%d", siteID, ruleID)
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(404)
@@ -238,7 +238,7 @@ func TestClientReadIncapRuleValidRule(t *testing.T) {
 	siteID := "42"
 	ruleID := 290109
 
-	endpoint := fmt.Sprintf("/sites/%s/rules/%d?api_id=%s&api_key=%s", siteID, ruleID, apiID, apiKey)
+	endpoint := fmt.Sprintf("/sites/%s/rules/%d", siteID, ruleID)
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(200)
@@ -307,7 +307,7 @@ func TestClientUpdateIncapRuleBadJSON(t *testing.T) {
 		Filter: "Full-URL == \"/someurl\"",
 	}
 
-	endpoint := fmt.Sprintf("/sites/%s/rules/%d?api_id=%s&api_key=%s", siteID, ruleID, apiID, apiKey)
+	endpoint := fmt.Sprintf("/sites/%s/rules/%d", siteID, ruleID)
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		if req.URL.String() != endpoint {
@@ -344,7 +344,7 @@ func TestClientUpdateIncapRuleInvalidRule(t *testing.T) {
 		Filter: "Full-URL == \"/someurl\"",
 	}
 
-	endpoint := fmt.Sprintf("/sites/%s/rules/%d?api_id=%s&api_key=%s", siteID, ruleID, apiID, apiKey)
+	endpoint := fmt.Sprintf("/sites/%s/rules/%d", siteID, ruleID)
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(404)
@@ -382,7 +382,7 @@ func TestClientUpdateIncapRuleValidRule(t *testing.T) {
 		Filter: "Full-URL == \"/someurl\"",
 	}
 
-	endpoint := fmt.Sprintf("/sites/%s/rules/%d?api_id=%s&api_key=%s", siteID, ruleID, apiID, apiKey)
+	endpoint := fmt.Sprintf("/sites/%s/rules/%d", siteID, ruleID)
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(200)
@@ -433,7 +433,7 @@ func TestClientDeleteIncapRuleInvalidRule(t *testing.T) {
 	siteID := "42"
 	ruleID := 11111
 
-	endpoint := fmt.Sprintf("/sites/%s/rules/%d?api_id=%s&api_key=%s", siteID, ruleID, apiID, apiKey)
+	endpoint := fmt.Sprintf("/sites/%s/rules/%d", siteID, ruleID)
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(404)
@@ -461,7 +461,7 @@ func TestClientDeleteIncapRuleValidRule(t *testing.T) {
 	siteID := "42"
 	ruleID := 290109
 
-	endpoint := fmt.Sprintf("/sites/%s/rules/%d?api_id=%s&api_key=%s", siteID, ruleID, apiID, apiKey)
+	endpoint := fmt.Sprintf("/sites/%s/rules/%d", siteID, ruleID)
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(200)

--- a/incapsula/client_log_level.go
+++ b/incapsula/client_log_level.go
@@ -24,13 +24,13 @@ func (c *Client) UpdateLogLevel(siteID, logLevel, logsAccountId string) error {
 	log.Printf("[INFO] Updating Incapsula log level (%s) for siteID: %s\n", logLevel, siteID)
 
 	// Post form to Incapsula
-	resp, err := c.httpClient.PostForm(fmt.Sprintf("%s/%s", c.config.BaseURL, endpointSiteLogLevel), url.Values{
-		"api_id":          {c.config.APIID},
-		"api_key":         {c.config.APIKey},
+	values := url.Values{
 		"site_id":         {siteID},
 		"log_level":       {logLevel},
 		"logs_account_id": {logsAccountId},
-	})
+	}
+	reqURL := fmt.Sprintf("%s/%s", c.config.BaseURL, endpointSiteLogLevel)
+	resp, err := c.PostFormWithHeaders(reqURL, values)
 	if err != nil {
 		return fmt.Errorf("Error updating log level (%s) on site_id: %s: %s", logLevel, siteID, err)
 	}

--- a/incapsula/client_origin_pop.go
+++ b/incapsula/client_origin_pop.go
@@ -19,22 +19,12 @@ type SetOriginPOPResponse struct {
 
 // SetOriginPOP sets the origin POP for given data center
 func (c *Client) SetOriginPOP(dcID int, originPOP string) error {
-	originPopModifyUrl := ""
+	reqURL := fmt.Sprintf("%s/sites/datacenter/origin-pop/modify?dc_id=%d", c.config.BaseURL, dcID)
 	if originPOP != "" {
-		originPopModifyUrl = fmt.Sprintf("%s/sites/datacenter/origin-pop/modify?api_id=%s&api_key=%s&origin_pop=%s&dc_id=%d", c.config.BaseURL, c.config.APIID, c.config.APIKey, originPOP, dcID)
-	} else { // setting the origin pop to NONE is done by not sending the origin_pop query param
-		originPopModifyUrl = fmt.Sprintf("%s/sites/datacenter/origin-pop/modify?api_id=%s&api_key=%s&dc_id=%d", c.config.BaseURL, c.config.APIID, c.config.APIKey, dcID)
+		reqURL = fmt.Sprintf("%s&origin_pop=%s", reqURL, originPOP)
 	}
-
 	// Post request to Incapsula
-	req, err := http.NewRequest(
-		http.MethodPost,
-		originPopModifyUrl,
-		nil)
-	if err != nil {
-		return fmt.Errorf("Error preparing HTTP POST for setting Incapsula origin POP: %s for data center: %d: %s", originPOP, dcID, err)
-	}
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.DoJsonRequestWithHeaders(http.MethodPost, reqURL, nil)
 	if err != nil {
 		return fmt.Errorf("Error from Incapsula service when setting origin POP: %s for data center: %d: %s", originPOP, dcID, err)
 	}

--- a/incapsula/client_performance.go
+++ b/incapsula/client_performance.go
@@ -1,7 +1,6 @@
 package incapsula
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -55,7 +54,8 @@ func (c *Client) GetPerformanceSettings(siteID string) (*PerformanceSettings, in
 	log.Printf("[INFO] Getting Incapsula Performance Settings for Site ID %s\n", siteID)
 
 	// Post form to Incapsula
-	resp, err := c.httpClient.Get(fmt.Sprintf("%s/sites/%s/settings/cache?api_id=%s&api_key=%s", c.config.BaseURLRev2, siteID, c.config.APIID, c.config.APIKey))
+	reqURL := fmt.Sprintf("%s/sites/%s/settings/cache", c.config.BaseURLRev2, siteID)
+	resp, err := c.DoJsonRequestWithHeaders(http.MethodGet, reqURL, nil)
 	if err != nil {
 		return nil, 0, fmt.Errorf("Error from Incapsula service when reading Incap Performance Settings for Site ID %s: %s", siteID, err)
 	}
@@ -93,14 +93,8 @@ func (c *Client) UpdatePerformanceSettings(siteID string, performanceSettings *P
 
 	// Post request to Incapsula
 	log.Printf("[DEBUG] Incapsula Update Incap Performance Settings JSON request: %s\n", string(performanceSettingsJSON))
-	req, err := http.NewRequest(
-		http.MethodPut,
-		fmt.Sprintf("%s/sites/%s/settings/cache?api_id=%s&api_key=%s", c.config.BaseURLRev2, siteID, c.config.APIID, c.config.APIKey),
-		bytes.NewReader(performanceSettingsJSON))
-	if err != nil {
-		return nil, fmt.Errorf("Error preparing HTTP POST for updating Incap Performance Settings for Site ID %s: %s", siteID, err)
-	}
-	resp, err := c.httpClient.Do(req)
+	reqURL := fmt.Sprintf("%s/sites/%s/settings/cache", c.config.BaseURLRev2, siteID)
+	resp, err := c.DoJsonRequestWithHeaders(http.MethodPut, reqURL, performanceSettingsJSON)
 	if err != nil {
 		return nil, fmt.Errorf("Error from Incapsula service when updating Incap Performance Settings for Site ID %s: %s", siteID, err)
 	}

--- a/incapsula/client_performance_test.go
+++ b/incapsula/client_performance_test.go
@@ -34,7 +34,7 @@ func TestClientGetPerformanceSettingsBadJSON(t *testing.T) {
 	apiKey := "bar"
 	siteID := "42"
 
-	endpoint := fmt.Sprintf("/sites/%s/settings/cache?api_id=%s&api_key=%s", siteID, apiID, apiKey)
+	endpoint := fmt.Sprintf("/sites/%s/settings/cache", siteID)
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		if req.URL.String() != endpoint {
@@ -64,7 +64,7 @@ func TestClientGetPerformanceSettingsInvalidSite(t *testing.T) {
 	apiKey := "bar"
 	siteID := "42"
 
-	endpoint := fmt.Sprintf("/sites/%s/settings/cache?api_id=%s&api_key=%s", siteID, apiID, apiKey)
+	endpoint := fmt.Sprintf("/sites/%s/settings/cache", siteID)
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(404)
@@ -95,7 +95,7 @@ func TestClientGetPerformanceSettingsValidSite(t *testing.T) {
 	apiKey := "bar"
 	siteID := "42"
 
-	endpoint := fmt.Sprintf("/sites/%s/settings/cache?api_id=%s&api_key=%s", siteID, apiID, apiKey)
+	endpoint := fmt.Sprintf("/sites/%s/settings/cache", siteID)
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		if req.URL.String() != endpoint {
@@ -146,7 +146,7 @@ func TestClientUpdatePerformanceSettingsInvalidSite(t *testing.T) {
 	performanceSettings := PerformanceSettings{}
 	performanceSettings.Mode.HTTPS = "include_all_resources"
 
-	endpoint := fmt.Sprintf("/sites/%s/settings/cache?api_id=%s&api_key=%s", siteID, apiID, apiKey)
+	endpoint := fmt.Sprintf("/sites/%s/settings/cache", siteID)
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(404)
@@ -176,7 +176,7 @@ func TestClientUpdatePerformanceSettingsValidSite(t *testing.T) {
 	performanceSettings := PerformanceSettings{}
 	performanceSettings.Mode.HTTPS = "include_all_resources"
 
-	endpoint := fmt.Sprintf("/sites/%s/settings/cache?api_id=%s&api_key=%s", siteID, apiID, apiKey)
+	endpoint := fmt.Sprintf("/sites/%s/settings/cache", siteID)
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		if req.URL.String() != endpoint {

--- a/incapsula/client_policy.go
+++ b/incapsula/client_policy.go
@@ -1,7 +1,6 @@
 package incapsula
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -80,10 +79,8 @@ func (c *Client) AddPolicy(policySubmitted *PolicySubmitted) (*PolicyExtended, e
 
 	// Post form to Incapsula
 	log.Printf("[DEBUG] Incapsula Add Incap Policy JSON request: %s\n", string(policyJSON))
-	resp, err := c.httpClient.Post(
-		fmt.Sprintf("%s/policies/v2/policies?api_id=%s&api_key=%s", c.config.BaseURLAPI, c.config.APIID, c.config.APIKey),
-		"application/json",
-		bytes.NewReader(policyJSON))
+	reqURL := fmt.Sprintf("%s/policies/v2/policies", c.config.BaseURLAPI)
+	resp, err := c.DoJsonRequestWithHeaders(http.MethodPost, reqURL, policyJSON)
 	if err != nil {
 		return nil, fmt.Errorf("Error from Incapsula service when adding Policy: %s", err)
 	}
@@ -115,7 +112,8 @@ func (c *Client) GetPolicy(policyID string) (*PolicyExtended, error) {
 	log.Printf("[INFO] Getting Incapsula Policy: %s\n", policyID)
 
 	// Post form to Incapsula
-	resp, err := c.httpClient.Get(fmt.Sprintf("%s/policies/v2/policies/%s?extended=true&api_id=%s&api_key=%s", c.config.BaseURLAPI, policyID, c.config.APIID, c.config.APIKey))
+	reqURL := fmt.Sprintf("%s/policies/v2/policies/%s?extended=true", c.config.BaseURLAPI, policyID)
+	resp, err := c.DoJsonRequestWithHeaders(http.MethodGet, reqURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("Error from Incapsula service when reading Policy for ID %s: %s", policyID, err)
 	}
@@ -153,15 +151,8 @@ func (c *Client) UpdatePolicy(policyID int, policySubmitted *PolicySubmitted) (*
 
 	// Post form to Incapsula
 	log.Printf("[DEBUG] Incapsula Update Incap Policy JSON request: %s\n", string(policyJSON))
-	req, err := http.NewRequest(
-		http.MethodPut,
-		fmt.Sprintf("%s/policies/v2/policies/%d?api_id=%s&api_key=%s", c.config.BaseURLAPI, policyID, c.config.APIID, c.config.APIKey),
-		bytes.NewReader(policyJSON))
-	if err != nil {
-		return nil, fmt.Errorf("Error preparing HTTP PUT for updating Incap Policy with ID %d: %s", policyID, err)
-	}
-	req.Header.Set("Content-Type", "application/json; charset=utf-8")
-	resp, err := c.httpClient.Do(req)
+	reqURL := fmt.Sprintf("%s/policies/v2/policies/%d", c.config.BaseURLAPI, policyID)
+	resp, err := c.DoJsonRequestWithHeaders(http.MethodPut, reqURL, policyJSON)
 	if err != nil {
 		return nil, fmt.Errorf("Error from Incapsula service when updating Policy: %s", err)
 	}
@@ -193,14 +184,8 @@ func (c *Client) DeletePolicy(policyID string) error {
 	log.Printf("[INFO] Deleting Incapsula Policy for ID %s\n", policyID)
 
 	// Delete request to Incapsula
-	req, err := http.NewRequest(
-		http.MethodDelete,
-		fmt.Sprintf("%s/policies/v2/policies/%s?api_id=%s&api_key=%s", c.config.BaseURLAPI, policyID, c.config.APIID, c.config.APIKey),
-		nil)
-	if err != nil {
-		return fmt.Errorf("Error preparing HTTP DELETE for deleting Policy with ID %s: %s", policyID, err)
-	}
-	resp, err := c.httpClient.Do(req)
+	reqURL := fmt.Sprintf("%s/policies/v2/policies/%s", c.config.BaseURLAPI, policyID)
+	resp, err := c.DoJsonRequestWithHeaders(http.MethodDelete, reqURL, nil)
 	if err != nil {
 		return fmt.Errorf("Error from Incapsula service when deleting Policy with ID %s: %s", policyID, err)
 	}

--- a/incapsula/client_policy_asset_association.go
+++ b/incapsula/client_policy_asset_association.go
@@ -18,10 +18,8 @@ func (c *Client) AddPolicyAssetAssociation(policyID, assetID, assetType string) 
 	log.Printf("[INFO] Adding Incapsula Policy Asset Association: %s-%s-%s\n", policyID, assetID, assetType)
 
 	// Post form to Incapsula
-	resp, err := c.httpClient.Post(
-		fmt.Sprintf("%s/policies/v2/assets/%s/%s/policies/%s?api_id=%s&api_key=%s", c.config.BaseURLAPI, assetType, assetID, policyID, c.config.APIID, c.config.APIKey),
-		"application/json",
-		nil)
+	reqURL := fmt.Sprintf("%s/policies/v2/assets/%s/%s/policies/%s", c.config.BaseURLAPI, assetType, assetID, policyID)
+	resp, err := c.DoJsonRequestWithHeaders(http.MethodPost, reqURL, nil)
 	if err != nil {
 		return fmt.Errorf("Error from Incapsula service when adding Policy Asset Association: %s", err)
 	}
@@ -46,14 +44,8 @@ func (c *Client) DeletePolicyAssetAssociation(policyID, assetID, assetType strin
 	log.Printf("[INFO] Deleting Incapsula Policy Asset Association: %s-%s-%s\n", policyID, assetID, assetType)
 
 	// Delete request to Incapsula
-	req, err := http.NewRequest(
-		http.MethodDelete,
-		fmt.Sprintf("%s/policies/v2/assets/%s/%s/policies/%s?api_id=%s&api_key=%s", c.config.BaseURLAPI, assetType, assetID, policyID, c.config.APIID, c.config.APIKey),
-		nil)
-	if err != nil {
-		return fmt.Errorf("Error preparing HTTP DELETE for deleting Policy Asset Association: %s", err)
-	}
-	resp, err := c.httpClient.Do(req)
+	reqURL := fmt.Sprintf("%s/policies/v2/assets/%s/%s/policies/%s", c.config.BaseURLAPI, assetType, assetID, policyID)
+	resp, err := c.DoJsonRequestWithHeaders(http.MethodDelete, reqURL, nil)
 	if err != nil {
 		return fmt.Errorf("Error from Incapsula service when deleting Policy Asset Association (%s): %s", policyID, err)
 	}
@@ -77,7 +69,8 @@ func (c *Client) isPolicyAssetAssociated(policyID, assetID, assetType string) (b
 	log.Printf("[INFO] Checking Policy Asset Association: %s-%s-%s\n", policyID, assetID, assetType)
 
 	// Check with Policies if the association exist
-	resp, err := c.httpClient.Get(fmt.Sprintf("%s/policies/v2/policies/%s/assets/%s/%s?api_id=%s&api_key=%s", c.config.BaseURLAPI, policyID, assetType, assetID, c.config.APIID, c.config.APIKey))
+	reqURL := fmt.Sprintf("%s/policies/v2/policies/%s/assets/%s/%s", c.config.BaseURLAPI, policyID, assetType, assetID)
+	resp, err := c.DoJsonRequestWithHeaders(http.MethodGet, reqURL, nil)
 	if err != nil {
 		return false, fmt.Errorf("error from Incapsula service when checking if Policy Asset Association exist: %s-%s-%s, err: %s", policyID, assetID, assetType, err)
 	}

--- a/incapsula/client_policy_asset_association_test.go
+++ b/incapsula/client_policy_asset_association_test.go
@@ -37,7 +37,7 @@ func ClientPolicyAssetAssociatedBase(t *testing.T, shouldBeAssociated bool) (boo
 	policyID := "11"
 	assetType := "WEBSITE"
 
-	endpoint := fmt.Sprintf("/policies/v2/policies/%s/assets/%s/%s?api_id=%s&api_key=%s", policyID, assetType, assetID, apiID, apiKey)
+	endpoint := fmt.Sprintf("/policies/v2/policies/%s/assets/%s/%s", policyID, assetType, assetID)
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		if req.URL.String() != endpoint {
 			t.Errorf("Should have have hit %s endpoint. Got: %s", endpoint, req.URL.String())

--- a/incapsula/client_security_rule_exception.go
+++ b/incapsula/client_security_rule_exception.go
@@ -41,8 +41,6 @@ type SecurityRuleExceptionCreateResponse struct {
 func (c *Client) AddSecurityRuleException(siteID int, ruleID, clientAppTypes, clientApps, countries, continents, ips, urlPatterns, urls, userAgents, parameters string) (*SecurityRuleExceptionCreateResponse, error) {
 	// Base URL values
 	values := url.Values{
-		"api_id":            {c.config.APIID},
-		"api_key":           {c.config.APIKey},
 		"site_id":           {strconv.Itoa(siteID)},
 		"rule_id":           {ruleID},
 		"exception_id_only": {"true"},
@@ -80,7 +78,8 @@ func (c *Client) AddSecurityRuleException(siteID int, ruleID, clientAppTypes, cl
 	}
 
 	// Post form to Incapsula
-	resp, err := c.httpClient.PostForm(fmt.Sprintf("%s/%s", c.config.BaseURL, endpointExceptionConfigure), values)
+	reqURL := fmt.Sprintf("%s/%s", c.config.BaseURL, endpointExceptionConfigure)
+	resp, err := c.PostFormWithHeaders(reqURL, values)
 	if err != nil {
 		return nil, fmt.Errorf("Error configuring security rule exception rule_id (%s) for site_id (%d)", ruleID, siteID)
 	}
@@ -111,8 +110,6 @@ func (c *Client) AddSecurityRuleException(siteID int, ruleID, clientAppTypes, cl
 func (c *Client) EditSecurityRuleException(siteID int, ruleID, clientAppTypes, clientApps, countries, continents, ips, urlPatterns, urls, userAgents, parameters, whitelistID string) (*SiteStatusResponse, error) {
 	// Base URL values
 	values := url.Values{
-		"api_id":       {c.config.APIID},
-		"api_key":      {c.config.APIKey},
 		"site_id":      {strconv.Itoa(siteID)},
 		"rule_id":      {ruleID},
 		"whitelist_id": {whitelistID},
@@ -150,7 +147,8 @@ func (c *Client) EditSecurityRuleException(siteID int, ruleID, clientAppTypes, c
 	}
 
 	// Post form to Incapsula
-	resp, err := c.httpClient.PostForm(fmt.Sprintf("%s/%s", c.config.BaseURL, endpointExceptionConfigure), values)
+	reqURL := fmt.Sprintf("%s/%s", c.config.BaseURL, endpointExceptionConfigure)
+	resp, err := c.PostFormWithHeaders(reqURL, values)
 	if err != nil {
 		return nil, fmt.Errorf("Error configuring security rule exception rule_id (%s) for site_id (%d)", ruleID, siteID)
 	}
@@ -182,11 +180,9 @@ func (c *Client) ListSecurityRuleExceptions(siteID, ruleID string) (*SiteStatusR
 	log.Printf("[INFO] Getting Incapsula security rule exeptions for rule_id (%s) on site_id (%s)\n", ruleID, siteID)
 
 	// Post form to Incapsula
-	resp, err := c.httpClient.PostForm(fmt.Sprintf("%s/%s", c.config.BaseURL, endpointExceptionList), url.Values{
-		"api_id":  {c.config.APIID},
-		"api_key": {c.config.APIKey},
-		"site_id": {siteID},
-	})
+	values := url.Values{"site_id": {siteID}}
+	reqURL := fmt.Sprintf("%s/%s", c.config.BaseURL, endpointExceptionList)
+	resp, err := c.PostFormWithHeaders(reqURL, values)
 	if err != nil {
 		return nil, fmt.Errorf("Error getting security rule exceptions for rule_id (%s) on siteID (%s): %s", ruleID, siteID, err)
 	}
@@ -233,8 +229,6 @@ func (c *Client) DeleteSecurityRuleException(siteID int, ruleID, whitelistID str
 
 	// Base URL values
 	values := url.Values{
-		"api_id":           {c.config.APIID},
-		"api_key":          {c.config.APIKey},
 		"site_id":          {strconv.Itoa(siteID)},
 		"rule_id":          {ruleID},
 		"whitelist_id":     {whitelistID},
@@ -242,7 +236,8 @@ func (c *Client) DeleteSecurityRuleException(siteID int, ruleID, whitelistID str
 	}
 
 	// Post form to Incapsula
-	resp, err := c.httpClient.PostForm(fmt.Sprintf("%s/%s", c.config.BaseURL, endpointExceptionConfigure), values)
+	reqURL := fmt.Sprintf("%s/%s", c.config.BaseURL, endpointExceptionConfigure)
+	resp, err := c.PostFormWithHeaders(reqURL, values)
 	if err != nil {
 		return fmt.Errorf("Error deleting security rule exception whitelist_id (%s) for rule_id (%s) for site_id (%d)", whitelistID, ruleID, siteID)
 	}

--- a/incapsula/client_site.go
+++ b/incapsula/client_site.go
@@ -212,8 +212,6 @@ func (c *Client) AddSite(domain, refID, sendSiteSetupEmails, siteIP, forceSSL st
 	log.Printf("[INFO] Adding Incapsula site for domain: %s (account ID %d)\n", domain, accountID)
 
 	values := url.Values{
-		"api_id":                 {c.config.APIID},
-		"api_key":                {c.config.APIKey},
 		"domain":                 {domain},
 		"ref_id":                 {refID},
 		"send_site_setup_emails": {sendSiteSetupEmails},
@@ -228,7 +226,8 @@ func (c *Client) AddSite(domain, refID, sendSiteSetupEmails, siteIP, forceSSL st
 		values["account_id"][0] = fmt.Sprint(accountID)
 	}
 
-	resp, err := c.httpClient.PostForm(fmt.Sprintf("%s/%s", c.config.BaseURL, endpointSiteAdd), values)
+	reqURL := fmt.Sprintf("%s/%s", c.config.BaseURL, endpointSiteAdd)
+	resp, err := c.PostFormWithHeaders(reqURL, values)
 	if err != nil {
 		return nil, fmt.Errorf("Error adding site for domain %s: %s", domain, err)
 	}
@@ -260,11 +259,9 @@ func (c *Client) SiteStatus(domain string, siteID int) (*SiteStatusResponse, err
 	log.Printf("[INFO] Getting Incapsula site status for domain: %s (site id: %d)\n", domain, siteID)
 
 	// Post form to Incapsula
-	resp, err := c.httpClient.PostForm(fmt.Sprintf("%s/%s", c.config.BaseURL, endpointSiteStatus), url.Values{
-		"api_id":  {c.config.APIID},
-		"api_key": {c.config.APIKey},
-		"site_id": {strconv.Itoa(siteID)},
-	})
+	values := url.Values{"site_id": {strconv.Itoa(siteID)}}
+	reqURL := fmt.Sprintf("%s/%s", c.config.BaseURL, endpointSiteStatus)
+	resp, err := c.PostFormWithHeaders(reqURL, values)
 	if err != nil {
 		return nil, fmt.Errorf("Error getting site status for domain %s (site id: %d): %s", domain, siteID, err)
 	}
@@ -304,13 +301,13 @@ func (c *Client) UpdateSite(siteID, param, value string) (*SiteUpdateResponse, e
 	log.Printf("[INFO] Updating Incapsula site for siteID: %s\n", siteID)
 
 	// Post form to Incapsula
-	resp, err := c.httpClient.PostForm(fmt.Sprintf("%s/%s", c.config.BaseURL, endpointSiteUpdate), url.Values{
-		"api_id":  {c.config.APIID},
-		"api_key": {c.config.APIKey},
+	values := url.Values{
 		"site_id": {siteID},
 		"param":   {param},
 		"value":   {value},
-	})
+	}
+	reqURL := fmt.Sprintf("%s/%s", c.config.BaseURL, endpointSiteUpdate)
+	resp, err := c.PostFormWithHeaders(reqURL, values)
 	if err != nil {
 		return nil, fmt.Errorf("Error updating param (%s) with value (%s) on site_id: %s: %s", param, value, siteID, err)
 	}
@@ -349,11 +346,9 @@ func (c *Client) DeleteSite(domain string, siteID int) error {
 	log.Printf("[INFO] Deleting Incapsula site for domain: %s (site id: %d)\n", domain, siteID)
 
 	// Post form to Incapsula
-	resp, err := c.httpClient.PostForm(fmt.Sprintf("%s/%s", c.config.BaseURL, endpointSiteDelete), url.Values{
-		"api_id":  {c.config.APIID},
-		"api_key": {c.config.APIKey},
-		"site_id": {strconv.Itoa(siteID)},
-	})
+	values := url.Values{"site_id": {strconv.Itoa(siteID)}}
+	reqURL := fmt.Sprintf("%s/%s", c.config.BaseURL, endpointSiteDelete)
+	resp, err := c.PostFormWithHeaders(reqURL, values)
 	if err != nil {
 		return fmt.Errorf("Error deleting site for domain %s (site id: %d): %s", domain, siteID, err)
 	}

--- a/incapsula/client_site_masking_settings.go
+++ b/incapsula/client_site_masking_settings.go
@@ -1,7 +1,6 @@
 package incapsula
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -20,7 +19,8 @@ func (c *Client) GetMaskingSettings(siteID string) (*MaskingSettings, error) {
 	log.Printf("[INFO] Getting Incapsula Masking Settings for Site ID %s\n", siteID)
 
 	// Post form to Incapsula
-	resp, err := c.httpClient.Get(fmt.Sprintf("%s/sites/%s/settings/masking?api_id=%s&api_key=%s", c.config.BaseURLRev2, siteID, c.config.APIID, c.config.APIKey))
+	reqURL := fmt.Sprintf("%s/sites/%s/settings/masking", c.config.BaseURLRev2, siteID)
+	resp, err := c.DoJsonRequestWithHeaders(http.MethodGet, reqURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("Error from Incapsula service when reading masking settings for Site ID %s: %s", siteID, err)
 	}
@@ -57,14 +57,8 @@ func (c *Client) UpdateMaskingSettings(siteID string, maskingSettings *MaskingSe
 	}
 
 	// Put request to Incapsula
-	req, err := http.NewRequest(
-		http.MethodPost,
-		fmt.Sprintf("%s/sites/%s/settings/masking?api_id=%s&api_key=%s", c.config.BaseURLRev2, siteID, c.config.APIID, c.config.APIKey),
-		bytes.NewReader(maskingSettingsJSON))
-	if err != nil {
-		return fmt.Errorf("Error preparing HTTP PUT for updating Incap masking settings for Site ID %s: %s", siteID, err)
-	}
-	resp, err := c.httpClient.Do(req)
+	reqURL := fmt.Sprintf("%s/sites/%s/settings/masking", c.config.BaseURLRev2, siteID)
+	resp, err := c.DoJsonRequestWithHeaders(http.MethodPost, reqURL, maskingSettingsJSON)
 	if err != nil {
 		return fmt.Errorf("Error from Incapsula service when updating masking settings for Site ID %s: %s", siteID, err)
 	}

--- a/incapsula/client_site_masking_settings_test.go
+++ b/incapsula/client_site_masking_settings_test.go
@@ -34,7 +34,7 @@ func TestClientGetMaskingSettingsBadJSON(t *testing.T) {
 	apiKey := "bar"
 	siteID := "42"
 
-	endpoint := fmt.Sprintf("/sites/%s/settings/masking?api_id=%s&api_key=%s", siteID, apiID, apiKey)
+	endpoint := fmt.Sprintf("/sites/%s/settings/masking", siteID)
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		if req.URL.String() != endpoint {
@@ -64,7 +64,7 @@ func TestClientGetMaskingSettingsInvalidSite(t *testing.T) {
 	apiKey := "bar"
 	siteID := "42"
 
-	endpoint := fmt.Sprintf("/sites/%s/settings/masking?api_id=%s&api_key=%s", siteID, apiID, apiKey)
+	endpoint := fmt.Sprintf("/sites/%s/settings/masking", siteID)
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(404)
@@ -95,7 +95,7 @@ func TestClientGetMaskingSettingsValidSite(t *testing.T) {
 	apiKey := "bar"
 	siteID := "42"
 
-	endpoint := fmt.Sprintf("/sites/%s/settings/masking?api_id=%s&api_key=%s", siteID, apiID, apiKey)
+	endpoint := fmt.Sprintf("/sites/%s/settings/masking", siteID)
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		if req.URL.String() != endpoint {
@@ -147,7 +147,7 @@ func TestClientUpdateMaskingSettingsInvalidSite(t *testing.T) {
 	siteID := "42"
 	maskingSettings := MaskingSettings{HashingEnabled: true, HashSalt: "salt"}
 
-	endpoint := fmt.Sprintf("/sites/%s/settings/masking?api_id=%s&api_key=%s", siteID, apiID, apiKey)
+	endpoint := fmt.Sprintf("/sites/%s/settings/masking", siteID)
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(404)
@@ -176,7 +176,7 @@ func TestClientUpdateMaskingSettingsValidSite(t *testing.T) {
 	siteID := "42"
 	maskingSettings := MaskingSettings{HashingEnabled: true, HashSalt: "salt"}
 
-	endpoint := fmt.Sprintf("/sites/%s/settings/masking?api_id=%s&api_key=%s", siteID, apiID, apiKey)
+	endpoint := fmt.Sprintf("/sites/%s/settings/masking", siteID)
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		if req.URL.String() != endpoint {

--- a/incapsula/client_site_txt_settings.go
+++ b/incapsula/client_site_txt_settings.go
@@ -38,7 +38,8 @@ func (c *Client) ReadTXTRecords(siteID int) (*TXTRecordResponse, error) {
 	log.Printf("[INFO] Getting Incapsula TXT record(s) for siteID %d\n", siteID)
 
 	// GET records from Incapsula
-	resp, err := c.httpClient.Get(fmt.Sprintf("%s/sites/%d/settings/general/additionalTxtRecords?api_id=%s&api_key=%s", c.config.BaseURLRev2, siteID, c.config.APIID, c.config.APIKey))
+	reqURL := fmt.Sprintf("%s/sites/%d/settings/general/additionalTxtRecords", c.config.BaseURLRev2, siteID)
+	resp, err := c.DoJsonRequestWithHeaders(http.MethodGet, reqURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("Error from Incapsula service when reading TXT record(s) for siteID: %d\n %s", siteID, err)
 	}
@@ -71,9 +72,7 @@ func (c *Client) CreateTXTRecord(siteID int, txtRecordValueOne string, txtRecord
 	log.Printf("[INFO] Create Incapsula TXT record(s) for siteID %d\n txt_record_value_one=%s, txt_record_value_two=%s, txt_record_value_three=%s, txt_record_value_four=%s, txt_record_value_five=%s", siteID, txtRecordValueOne, txtRecordValueTwo, txtRecordValueThree, txtRecordValueFour, txtRecordValueFive)
 
 	// Post request to Incapsula
-	record := url.Values{
-		"api_id":                 {c.config.APIID},
-		"api_key":                {c.config.APIKey},
+	values := url.Values{
 		"txt_record_value_one":   {txtRecordValueOne},
 		"txt_record_value_two":   {txtRecordValueTwo},
 		"txt_record_value_three": {txtRecordValueThree},
@@ -82,10 +81,8 @@ func (c *Client) CreateTXTRecord(siteID int, txtRecordValueOne string, txtRecord
 	}
 
 	// Post request to Incapsula
-	resp, err := c.httpClient.PostForm(
-		fmt.Sprintf("%s/sites/%d/settings/general/additionalTxtRecords",
-			c.config.BaseURLRev2, siteID), record)
-
+	reqURL := fmt.Sprintf("%s/sites/%d/settings/general/additionalTxtRecords", c.config.BaseURLRev2, siteID)
+	resp, err := c.PostFormWithHeaders(reqURL, values)
 	if err != nil {
 		return nil, fmt.Errorf("Error creating TXT record(s) for siteID %d: %s", siteID, err)
 	}
@@ -119,9 +116,7 @@ func (c *Client) UpdateTXTRecord(siteID int, txtRecordValueOne string, txtRecord
 		siteID, txtRecordValueOne, txtRecordValueTwo, txtRecordValueThree, txtRecordValueFour, txtRecordValueFive)
 
 	// Post request to Incapsula
-	record := url.Values{
-		"api_id":                 {c.config.APIID},
-		"api_key":                {c.config.APIKey},
+	values := url.Values{
 		"txt_record_value_one":   {txtRecordValueOne},
 		"txt_record_value_two":   {txtRecordValueTwo},
 		"txt_record_value_three": {txtRecordValueThree},
@@ -130,10 +125,8 @@ func (c *Client) UpdateTXTRecord(siteID int, txtRecordValueOne string, txtRecord
 	}
 
 	// Post request to Incapsula
-	resp, err := c.httpClient.PostForm(
-		fmt.Sprintf("%s/sites/%d/settings/general/additionalTxtRecords",
-			c.config.BaseURLRev2, siteID), record)
-
+	reqURL := fmt.Sprintf("%s/sites/%d/settings/general/additionalTxtRecords", c.config.BaseURLRev2, siteID)
+	resp, err := c.PostFormWithHeaders(reqURL, values)
 	if err != nil {
 		return nil, fmt.Errorf("Error updating TXT record(s) for siteID: %d\n%s", siteID, err)
 	}
@@ -166,15 +159,8 @@ func (c *Client) DeleteTXTRecord(siteID int, recordNumber string) error {
 	log.Printf("[INFO] Delete Incapsula TXT record number %d for siteID %s\n ", siteID, recordNumber)
 
 	// Post request to Incapsula
-	req, _ := http.NewRequest(
-		http.MethodDelete,
-		fmt.Sprintf("%s/sites/%d/settings/general/additionalTxtRecords?record_number=%s&api_id=%s&api_key=%s",
-			c.config.BaseURLRev2, siteID, recordNumber, c.config.APIID, c.config.APIKey),
-		nil,
-	)
-
-	resp, err := c.httpClient.Do(req)
-
+	reqURL := fmt.Sprintf("%s/sites/%d/settings/general/additionalTxtRecords?record_number=%s", c.config.BaseURLRev2, siteID, recordNumber)
+	resp, err := c.DoJsonRequestWithHeaders(http.MethodDelete, reqURL, nil)
 	if err != nil {
 		return fmt.Errorf("Error deleting TXT record(s) for siteID %d: %s", siteID, err)
 	}

--- a/incapsula/client_site_txt_settings_test.go
+++ b/incapsula/client_site_txt_settings_test.go
@@ -35,7 +35,7 @@ func TestClientGetTXTRecordsBadJSON(t *testing.T) {
 	apiKey := "bar"
 	siteID := 42
 
-	endpoint := fmt.Sprintf("/sites/%d/settings/general/additionalTxtRecords?api_id=%s&api_key=%s", siteID, apiID, apiKey)
+	endpoint := fmt.Sprintf("/sites/%d/settings/general/additionalTxtRecords", siteID)
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		if req.URL.String() != endpoint {
@@ -65,7 +65,7 @@ func TestClientGetTXTRecordsInvalidSite(t *testing.T) {
 	apiKey := "bar"
 	siteID := 42
 
-	endpoint := fmt.Sprintf("/sites/%d/settings/general/additionalTxtRecords?api_id=%s&api_key=%s", siteID, apiID, apiKey)
+	endpoint := fmt.Sprintf("/sites/%d/settings/general/additionalTxtRecords", siteID)
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(404)
@@ -97,7 +97,7 @@ func TestClientGetTXTRecordsValidSite(t *testing.T) {
 	apiKey := "bar"
 	siteID := 42
 
-	endpoint := fmt.Sprintf("/sites/%d/settings/general/additionalTxtRecords?api_id=%s&api_key=%s", siteID, apiID, apiKey)
+	endpoint := fmt.Sprintf("/sites/%d/settings/general/additionalTxtRecords", siteID)
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		if req.URL.String() != endpoint {

--- a/incapsula/client_waf_security_rule.go
+++ b/incapsula/client_waf_security_rule.go
@@ -26,8 +26,6 @@ const customRuleDefaultActionID = "api.threats.customRule"
 func (c *Client) ConfigureWAFSecurityRule(siteID int, ruleID, securityRuleAction, activationMode, ddosTrafficThreshold, blockBadBots, challengeSuspectedBots string) (*SiteStatusResponse, error) {
 	// Base URL values
 	values := url.Values{
-		"api_id":  {c.config.APIID},
-		"api_key": {c.config.APIKey},
 		"site_id": {strconv.Itoa(siteID)},
 		"rule_id": {ruleID},
 	}
@@ -49,7 +47,8 @@ func (c *Client) ConfigureWAFSecurityRule(siteID int, ruleID, securityRuleAction
 	}
 
 	// Post form to Incapsula
-	resp, err := c.httpClient.PostForm(fmt.Sprintf("%s/%s", c.config.BaseURL, endpointWAFRuleConfigure), values)
+	reqURL := fmt.Sprintf("%s/%s", c.config.BaseURL, endpointWAFRuleConfigure)
+	resp, err := c.PostFormWithHeaders(reqURL, values)
 	if err != nil {
 		return nil, fmt.Errorf("Error configuring WAF security rule rule_id (%s) for site_id (%d)", ruleID, siteID)
 	}

--- a/incapsula/resource_account_test.go
+++ b/incapsula/resource_account_test.go
@@ -2,6 +2,7 @@ package incapsula
 
 import (
 	"fmt"
+	"os"
 	"strconv"
 	"testing"
 
@@ -12,6 +13,13 @@ import (
 const testEmail = "example@example.com"
 const accountResourceName = "incapsula_account.test-terraform-account"
 
+func GenerateTestEmail(t *testing.T) string {
+	if v := os.Getenv("INCAPSULA_API_ID"); v == "" {
+		t.Fatal("INCAPSULA_API_ID must be set for acceptance tests")
+	}
+	return "id" + os.Getenv("INCAPSULA_API_ID") + "." + testEmail
+}
+
 func TestIncapsulaAccount_Basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -19,10 +27,10 @@ func TestIncapsulaAccount_Basic(t *testing.T) {
 		CheckDestroy: testCheckIncapsulaAccountDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testCheckIncapsulaAccountConfigBasic(testEmail),
+				Config: testCheckIncapsulaAccountConfigBasic(GenerateTestEmail(t)),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckIncapsulaAccountExists(accountResourceName),
-					resource.TestCheckResourceAttr(accountResourceName, "email", testEmail),
+					resource.TestCheckResourceAttr(accountResourceName, "email", GenerateTestEmail(t)),
 				),
 			},
 		},
@@ -36,7 +44,7 @@ func TestIncapsulaAccount_ImportBasic(t *testing.T) {
 		CheckDestroy: testCheckIncapsulaAccountDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testCheckIncapsulaAccountConfigBasic(testEmail),
+				Config: testCheckIncapsulaAccountConfigBasic(GenerateTestEmail(t)),
 			},
 			{
 				ResourceName:      "incapsula_account.test-terraform-account",

--- a/incapsula/resource_cache_rule_test.go
+++ b/incapsula/resource_cache_rule_test.go
@@ -19,7 +19,7 @@ func TestAccIncapsulaCacheRule_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckIncapsulaCacheRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIncapsulaCacheRuleConfigBasic(),
+				Config: testAccCheckIncapsulaCacheRuleConfigBasic(t),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckIncapsulaCacheRuleExists(cacheRuleResourceName),
 					resource.TestCheckResourceAttr(cacheRuleResourceName, "name", cacheRuleName),
@@ -114,8 +114,8 @@ func testCheckIncapsulaCacheRuleExists(name string) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckIncapsulaCacheRuleConfigBasic() string {
-	return testAccCheckIncapsulaSiteConfigBasic(testAccDomain) + fmt.Sprintf(`
+func testAccCheckIncapsulaCacheRuleConfigBasic(t *testing.T) string {
+	return testAccCheckIncapsulaSiteConfigBasic(GenerateTestDomain(t)) + fmt.Sprintf(`
 resource "incapsula_cache_rule" "testacc-terraform-cache-rule" {
 	name = "%s"
   site_id = "${incapsula_site.testacc-terraform-site.id}"

--- a/incapsula/resource_certificate_test.go
+++ b/incapsula/resource_certificate_test.go
@@ -19,7 +19,7 @@ func testAccCheckCertificateUploadGoodConfig(t *testing.T) {
 		CheckDestroy: testAccCheckIncapsulaCertificateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIncapsulaCustomCertificateGoodConfig(),
+				Config: testAccCheckIncapsulaCustomCertificateGoodConfig(t),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckIncapsulaCertificateExists(certificateResourceName),
 					resource.TestCheckResourceAttr(certificateResourceName, "name", certificateName),
@@ -42,7 +42,7 @@ func testAccCheckCertificateUploadGoodConfigNoPrivateKey(t *testing.T) {
 		CheckDestroy: testAccCheckIncapsulaCertificateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIncapsulaCustomCertificateGoodConfigNoPrivateKey(),
+				Config: testAccCheckIncapsulaCustomCertificateGoodConfigNoPrivateKey(t),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckIncapsulaCertificateExists(certificateResourceName),
 					resource.TestCheckResourceAttr(certificateResourceName, "name", certificateName),
@@ -65,7 +65,7 @@ func testAccCheckCertificateUploadGoodConfigNoPassphrase(t *testing.T) {
 		CheckDestroy: testAccCheckIncapsulaCertificateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIncapsulaCustomCertificateGoodConfigNoPassphrase(),
+				Config: testAccCheckIncapsulaCustomCertificateGoodConfigNoPassphrase(t),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckIncapsulaCertificateExists(certificateResourceName),
 					resource.TestCheckResourceAttr(certificateResourceName, "name", certificateName),
@@ -88,7 +88,7 @@ func testAccCheckCertificateUploadBadKey(t *testing.T) {
 		CheckDestroy: testAccCheckIncapsulaCertificateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIncapsulaCustomCertificateBadKey(),
+				Config: testAccCheckIncapsulaCustomCertificateBadKey(t),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckIncapsulaCertificateExists(certificateResourceName),
 					resource.TestCheckResourceAttr(certificateResourceName, "name", certificateName),
@@ -111,7 +111,7 @@ func testAccCheckCertificateUploadBadCertificate(t *testing.T) {
 		CheckDestroy: testAccCheckIncapsulaCertificateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIncapsulaCustomCertificateBadCertificate(),
+				Config: testAccCheckIncapsulaCustomCertificateBadCertificate(t),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckIncapsulaCertificateExists(certificateResourceName),
 					resource.TestCheckResourceAttr(certificateResourceName, "name", certificateName),
@@ -134,7 +134,7 @@ func testAccCheckCertificateUploadBadPassphrase(t *testing.T) {
 		CheckDestroy: testAccCheckIncapsulaCertificateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIncapsulaCustomCertificateBadPassphrase(),
+				Config: testAccCheckIncapsulaCustomCertificateBadPassphrase(t),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckIncapsulaCertificateExists(certificateResourceName),
 					resource.TestCheckResourceAttr(certificateResourceName, "name", certificateName),
@@ -192,7 +192,7 @@ func testAccCheckIncapsulaCertificateDestroy(state *terraform.State) error {
 		//	}
 		//}
 		if err == "nil" {
-			return fmt.Errorf("Incapsula site for domain: %s (site id: %s) still exists", testAccDomain, siteID)
+			return fmt.Errorf("Incapsula site for domain: %s (site id: %s) still exists", GenerateTestDomain(nil), siteID)
 		}
 	}
 
@@ -207,8 +207,8 @@ func testCheckIncapsulaCertificateExists(name string) resource.TestCheckFunc {
 }
 
 // All variations of good and bad certificate configs
-func testAccCheckIncapsulaCustomCertificateGoodConfig() string {
-	return testAccCheckIncapsulaSiteConfigBasic(testAccDomain) + fmt.Sprintf("%s%s%s", `
+func testAccCheckIncapsulaCustomCertificateGoodConfig(t *testing.T) string {
+	return testAccCheckIncapsulaSiteConfigBasic(GenerateTestDomain(t)) + fmt.Sprintf("%s%s%s", `
 resource "incapsula_custom_certificate" "custom-certificate" {
   site_id = "${incapsula_site.example-site.id}"
   certificate = "-----BEGIN CERTIFICATE-----\nMIIDgjCCAmoCCQCk3MsAS5x+UjANBgkqhkiG9w0BAQsFADCBgjELMAkGA1UEBhMC\nVVMxCzAJBgNVBAgMAkNBMRIwEAYDVQQHDAlTYW4gRGllZ28xCzAJBgNVBAoMAlNF\nMQswCQYDVQQLDAJTRTEZMBcGA1UEAwwQZGFzaC5iZWVyLmNlbnRlcjEdMBsGCSqG\nSIb3DQEJARYOYmFAaW1wZXJ2YS5jb20wHhcNMTkwNzA4MTU0MjQ0WhcNMjAwNzA3\nMTU0MjQ0WjCBgjELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAkNBMRIwEAYDVQQHDAlT\nYW4gRGllZ28xCzAJBgNVBAoMAlNFMQswCQYDVQQLDAJTRTEZMBcGA1UEAwwQZGFz\naC5iZWVyLmNlbnRlcjEdMBsGCSqGSIb3DQEJARYOYmFAaW1wZXJ2YS5jb20wggEi\nMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCj0rYKUhVtNKQ/oKZdCfxvLKhQ\nLbCNsOt94afUZCbM93/TYj7kHQaapJ6s9snPjN6dvRKo/0h+qx1DhPRSDGgONdHe\n2plv6M7h2gNhBF2853/GZLdNzO9GBHDI6VB9bFJpQvqBl+Cy7nkPQ8dsPpE945lW\nsQ7KMakikp1oJrFHmfalNMo+VQgOKPNc3jUlgmSNEwk3Cf607DqdZUS/O4XSx+d0\n5kRg3hmrjDxDyTwG2gQDJBGkdZ87HUqd5NC7KlrY5xuLkloq4Rt1wqRdwGJsUdq6\nkC8lPmikw2i3peTUu03T3OiZxBpKK6gNMcKe3uA3zSPdoY/mDY2uWCBSY/OLAgMB\nAAEwDQYJKoZIhvcNAQELBQADggEBABfNZcItHdsSpfp8h+1EP5BnRuoKj+l42EI5\nE9dVlqdOZ25+V5Ee899sn2Nj8h+/zVU3+IDO2abUPrDd2xZHaHdf0p69htSwFTHs\nEwUdPUUsKRSys7fVP1clHcKWswTcoWIzQiPZsDMoOQw/pzN05cXSzdo8wSWuEeBK\ncqRNd5BKPeeXbFa4i5TFzT/+pl8V075k16tzHSbT7QDk5fuZWYv/2jImw/lgS/nx\nDWtlprrgG6AX1FzovDs/NnNq/e7vZtn8sdOoO2pCSVymNvctNLV2tFcS8sPQDl5M\nIpnZa3kktAegjsCln1JvD0AFigXrF8wjK+FKGI8SPJfbTQ149+A=\n-----END CERTIFICATE-----"
@@ -218,8 +218,8 @@ resource "incapsula_custom_certificate" "custom-certificate" {
 	)
 }
 
-func testAccCheckIncapsulaCustomCertificateGoodConfigNoPrivateKey() string {
-	return testAccCheckIncapsulaSiteConfigBasic(testAccDomain) + fmt.Sprintf("%s%s%s", `
+func testAccCheckIncapsulaCustomCertificateGoodConfigNoPrivateKey(t *testing.T) string {
+	return testAccCheckIncapsulaSiteConfigBasic(GenerateTestDomain(t)) + fmt.Sprintf("%s%s%s", `
 resource "incapsula_custom_certificate" "custom-certificate" {
   site_id = "${incapsula_site.example-site.id}"
   certificate = "-----BEGIN CERTIFICATE-----\nMIIDgjCCAmoCCQCk3MsAS5x+UjANBgkqhkiG9w0BAQsFADCBgjELMAkGA1UEBhMC\nVVMxCzAJBgNVBAgMAkNBMRIwEAYDVQQHDAlTYW4gRGllZ28xCzAJBgNVBAoMAlNF\nMQswCQYDVQQLDAJTRTEZMBcGA1UEAwwQZGFzaC5iZWVyLmNlbnRlcjEdMBsGCSqG\nSIb3DQEJARYOYmFAaW1wZXJ2YS5jb20wHhcNMTkwNzA4MTU0MjQ0WhcNMjAwNzA3\nMTU0MjQ0WjCBgjELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAkNBMRIwEAYDVQQHDAlT\nYW4gRGllZ28xCzAJBgNVBAoMAlNFMQswCQYDVQQLDAJTRTEZMBcGA1UEAwwQZGFz\naC5iZWVyLmNlbnRlcjEdMBsGCSqGSIb3DQEJARYOYmFAaW1wZXJ2YS5jb20wggEi\nMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCj0rYKUhVtNKQ/oKZdCfxvLKhQ\nLbCNsOt94afUZCbM93/TYj7kHQaapJ6s9snPjN6dvRKo/0h+qx1DhPRSDGgONdHe\n2plv6M7h2gNhBF2853/GZLdNzO9GBHDI6VB9bFJpQvqBl+Cy7nkPQ8dsPpE945lW\nsQ7KMakikp1oJrFHmfalNMo+VQgOKPNc3jUlgmSNEwk3Cf607DqdZUS/O4XSx+d0\n5kRg3hmrjDxDyTwG2gQDJBGkdZ87HUqd5NC7KlrY5xuLkloq4Rt1wqRdwGJsUdq6\nkC8lPmikw2i3peTUu03T3OiZxBpKK6gNMcKe3uA3zSPdoY/mDY2uWCBSY/OLAgMB\nAAEwDQYJKoZIhvcNAQELBQADggEBABfNZcItHdsSpfp8h+1EP5BnRuoKj+l42EI5\nE9dVlqdOZ25+V5Ee899sn2Nj8h+/zVU3+IDO2abUPrDd2xZHaHdf0p69htSwFTHs\nEwUdPUUsKRSys7fVP1clHcKWswTcoWIzQiPZsDMoOQw/pzN05cXSzdo8wSWuEeBK\ncqRNd5BKPeeXbFa4i5TFzT/+pl8V075k16tzHSbT7QDk5fuZWYv/2jImw/lgS/nx\nDWtlprrgG6AX1FzovDs/NnNq/e7vZtn8sdOoO2pCSVymNvctNLV2tFcS8sPQDl5M\nIpnZa3kktAegjsCln1JvD0AFigXrF8wjK+FKGI8SPJfbTQ149+A=\n-----END CERTIFICATE-----"
@@ -227,8 +227,8 @@ resource "incapsula_custom_certificate" "custom-certificate" {
 	)
 }
 
-func testAccCheckIncapsulaCustomCertificateGoodConfigNoPassphrase() string {
-	return testAccCheckIncapsulaSiteConfigBasic(testAccDomain) + fmt.Sprintf("%s%s%s", `
+func testAccCheckIncapsulaCustomCertificateGoodConfigNoPassphrase(t *testing.T) string {
+	return testAccCheckIncapsulaSiteConfigBasic(GenerateTestDomain(t)) + fmt.Sprintf("%s%s%s", `
 resource "incapsula_custom_certificate" "custom-certificate" {
   site_id = "${incapsula_site.example-site.id}"
   certificate = "-----BEGIN CERTIFICATE-----\nMIIDgjCCAmoCCQCk3MsAS5x+UjANBgkqhkiG9w0BAQsFADCBgjELMAkGA1UEBhMC\nVVMxCzAJBgNVBAgMAkNBMRIwEAYDVQQHDAlTYW4gRGllZ28xCzAJBgNVBAoMAlNF\nMQswCQYDVQQLDAJTRTEZMBcGA1UEAwwQZGFzaC5iZWVyLmNlbnRlcjEdMBsGCSqG\nSIb3DQEJARYOYmFAaW1wZXJ2YS5jb20wHhcNMTkwNzA4MTU0MjQ0WhcNMjAwNzA3\nMTU0MjQ0WjCBgjELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAkNBMRIwEAYDVQQHDAlT\nYW4gRGllZ28xCzAJBgNVBAoMAlNFMQswCQYDVQQLDAJTRTEZMBcGA1UEAwwQZGFz\naC5iZWVyLmNlbnRlcjEdMBsGCSqGSIb3DQEJARYOYmFAaW1wZXJ2YS5jb20wggEi\nMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCj0rYKUhVtNKQ/oKZdCfxvLKhQ\nLbCNsOt94afUZCbM93/TYj7kHQaapJ6s9snPjN6dvRKo/0h+qx1DhPRSDGgONdHe\n2plv6M7h2gNhBF2853/GZLdNzO9GBHDI6VB9bFJpQvqBl+Cy7nkPQ8dsPpE945lW\nsQ7KMakikp1oJrFHmfalNMo+VQgOKPNc3jUlgmSNEwk3Cf607DqdZUS/O4XSx+d0\n5kRg3hmrjDxDyTwG2gQDJBGkdZ87HUqd5NC7KlrY5xuLkloq4Rt1wqRdwGJsUdq6\nkC8lPmikw2i3peTUu03T3OiZxBpKK6gNMcKe3uA3zSPdoY/mDY2uWCBSY/OLAgMB\nAAEwDQYJKoZIhvcNAQELBQADggEBABfNZcItHdsSpfp8h+1EP5BnRuoKj+l42EI5\nE9dVlqdOZ25+V5Ee899sn2Nj8h+/zVU3+IDO2abUPrDd2xZHaHdf0p69htSwFTHs\nEwUdPUUsKRSys7fVP1clHcKWswTcoWIzQiPZsDMoOQw/pzN05cXSzdo8wSWuEeBK\ncqRNd5BKPeeXbFa4i5TFzT/+pl8V075k16tzHSbT7QDk5fuZWYv/2jImw/lgS/nx\nDWtlprrgG6AX1FzovDs/NnNq/e7vZtn8sdOoO2pCSVymNvctNLV2tFcS8sPQDl5M\nIpnZa3kktAegjsCln1JvD0AFigXrF8wjK+FKGI8SPJfbTQ149+A=\n-----END CERTIFICATE-----"
@@ -237,8 +237,8 @@ resource "incapsula_custom_certificate" "custom-certificate" {
 	)
 }
 
-func testAccCheckIncapsulaCustomCertificateBadKey() string {
-	return testAccCheckIncapsulaSiteConfigBasic(testAccDomain) + fmt.Sprintf("%s%s%s", `
+func testAccCheckIncapsulaCustomCertificateBadKey(t *testing.T) string {
+	return testAccCheckIncapsulaSiteConfigBasic(GenerateTestDomain(t)) + fmt.Sprintf("%s%s%s", `
 resource "incapsula_custom_certificate" "custom-certificate" {
   site_id = "${incapsula_site.example-site.id}"
   certificate = "-----BEGIN CERTIFICATE-----\nMIIDgjCCAmoCCQCk3MsAS5x+UjANBgkqhkiG9w0BAQsFADCBgjELMAkGA1UEBhMC\nVVMxCzAJBgNVBAgMAkNBMRIwEAYDVQQHDAlTYW4gRGllZ28xCzAJBgNVBAoMAlNF\nMQswCQYDVQQLDAJTRTEZMBcGA1UEAwwQZGFzaC5iZWVyLmNlbnRlcjEdMBsGCSqG\nSIb3DQEJARYOYmFAaW1wZXJ2YS5jb20wHhcNMTkwNzA4MTU0MjQ0WhcNMjAwNzA3\nMTU0MjQ0WjCBgjELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAkNBMRIwEAYDVQQHDAlT\nYW4gRGllZ28xCzAJBgNVBAoMAlNFMQswCQYDVQQLDAJTRTEZMBcGA1UEAwwQZGFz\naC5iZWVyLmNlbnRlcjEdMBsGCSqGSIb3DQEJARYOYmFAaW1wZXJ2YS5jb20wggEi\nMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCj0rYKUhVtNKQ/oKZdCfxvLKhQ\nLbCNsOt94afUZCbM93/TYj7kHQaapJ6s9snPjN6dvRKo/0h+qx1DhPRSDGgONdHe\n2plv6M7h2gNhBF2853/GZLdNzO9GBHDI6VB9bFJpQvqBl+Cy7nkPQ8dsPpE945lW\nsQ7KMakikp1oJrFHmfalNMo+VQgOKPNc3jUlgmSNEwk3Cf607DqdZUS/O4XSx+d0\n5kRg3hmrjDxDyTwG2gQDJBGkdZ87HUqd5NC7KlrY5xuLkloq4Rt1wqRdwGJsUdq6\nkC8lPmikw2i3peTUu03T3OiZxBpKK6gNMcKe3uA3zSPdoY/mDY2uWCBSY/OLAgMB\nAAEwDQYJKoZIhvcNAQELBQADggEBABfNZcItHdsSpfp8h+1EP5BnRuoKj+l42EI5\nE9dVlqdOZ25+V5Ee899sn2Nj8h+/zVU3+IDO2abUPrDd2xZHaHdf0p69htSwFTHs\nEwUdPUUsKRSys7fVP1clHcKWswTcoWIzQiPZsDMoOQw/pzN05cXSzdo8wSWuEeBK\ncqRNd5BKPeeXbFa4i5TFzT/+pl8V075k16tzHSbT7QDk5fuZWYv/2jImw/lgS/nx\nDWtlprrgG6AX1FzovDs/NnNq/e7vZtn8sdOoO2pCSVymNvctNLV2tFcS8sPQDl5M\nIpnZa3kktAegjsCln1JvD0AFigXrF8wjK+FKGI8SPJfbTQ149+A=\n-----END CERTIFICATE-----"
@@ -248,8 +248,8 @@ resource "incapsula_custom_certificate" "custom-certificate" {
 	)
 }
 
-func testAccCheckIncapsulaCustomCertificateBadCertificate() string {
-	return testAccCheckIncapsulaSiteConfigBasic(testAccDomain) + fmt.Sprintf("%s%s%s", `
+func testAccCheckIncapsulaCustomCertificateBadCertificate(t *testing.T) string {
+	return testAccCheckIncapsulaSiteConfigBasic(GenerateTestDomain(t)) + fmt.Sprintf("%s%s%s", `
 resource "incapsula_custom_certificate" "custom-certificate" {
   site_id = "${incapsula_site.example-site.id}"
   certificate = "some bad value"
@@ -259,8 +259,8 @@ resource "incapsula_custom_certificate" "custom-certificate" {
 	)
 }
 
-func testAccCheckIncapsulaCustomCertificateBadPassphrase() string {
-	return testAccCheckIncapsulaSiteConfigBasic(testAccDomain) + fmt.Sprintf("%s%s%s", `
+func testAccCheckIncapsulaCustomCertificateBadPassphrase(t *testing.T) string {
+	return testAccCheckIncapsulaSiteConfigBasic(GenerateTestDomain(t)) + fmt.Sprintf("%s%s%s", `
 resource "incapsula_custom_certificate" "custom-certificate" {
   site_id = "${incapsula_site.example-site.id}"
   certificate = "-----BEGIN CERTIFICATE-----\nMIIDgjCCAmoCCQCk3MsAS5x+UjANBgkqhkiG9w0BAQsFADCBgjELMAkGA1UEBhMC\nVVMxCzAJBgNVBAgMAkNBMRIwEAYDVQQHDAlTYW4gRGllZ28xCzAJBgNVBAoMAlNF\nMQswCQYDVQQLDAJTRTEZMBcGA1UEAwwQZGFzaC5iZWVyLmNlbnRlcjEdMBsGCSqG\nSIb3DQEJARYOYmFAaW1wZXJ2YS5jb20wHhcNMTkwNzA4MTU0MjQ0WhcNMjAwNzA3\nMTU0MjQ0WjCBgjELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAkNBMRIwEAYDVQQHDAlT\nYW4gRGllZ28xCzAJBgNVBAoMAlNFMQswCQYDVQQLDAJTRTEZMBcGA1UEAwwQZGFz\naC5iZWVyLmNlbnRlcjEdMBsGCSqGSIb3DQEJARYOYmFAaW1wZXJ2YS5jb20wggEi\nMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCj0rYKUhVtNKQ/oKZdCfxvLKhQ\nLbCNsOt94afUZCbM93/TYj7kHQaapJ6s9snPjN6dvRKo/0h+qx1DhPRSDGgONdHe\n2plv6M7h2gNhBF2853/GZLdNzO9GBHDI6VB9bFJpQvqBl+Cy7nkPQ8dsPpE945lW\nsQ7KMakikp1oJrFHmfalNMo+VQgOKPNc3jUlgmSNEwk3Cf607DqdZUS/O4XSx+d0\n5kRg3hmrjDxDyTwG2gQDJBGkdZ87HUqd5NC7KlrY5xuLkloq4Rt1wqRdwGJsUdq6\nkC8lPmikw2i3peTUu03T3OiZxBpKK6gNMcKe3uA3zSPdoY/mDY2uWCBSY/OLAgMB\nAAEwDQYJKoZIhvcNAQELBQADggEBABfNZcItHdsSpfp8h+1EP5BnRuoKj+l42EI5\nE9dVlqdOZ25+V5Ee899sn2Nj8h+/zVU3+IDO2abUPrDd2xZHaHdf0p69htSwFTHs\nEwUdPUUsKRSys7fVP1clHcKWswTcoWIzQiPZsDMoOQw/pzN05cXSzdo8wSWuEeBK\ncqRNd5BKPeeXbFa4i5TFzT/+pl8V075k16tzHSbT7QDk5fuZWYv/2jImw/lgS/nx\nDWtlprrgG6AX1FzovDs/NnNq/e7vZtn8sdOoO2pCSVymNvctNLV2tFcS8sPQDl5M\nIpnZa3kktAegjsCln1JvD0AFigXrF8wjK+FKGI8SPJfbTQ149+A=\n-----END CERTIFICATE-----"

--- a/incapsula/resource_data_center_server_test.go
+++ b/incapsula/resource_data_center_server_test.go
@@ -18,7 +18,7 @@ func TestAccIncapsulaDataCenterServer_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckIncapsulaDataCenterServerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIncapsulaDataCenterServerConfigBasic(),
+				Config: testAccCheckIncapsulaDataCenterServerConfigBasic(t),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckIncapsulaDataCenterServerExists(dataCenterServerResourceName),
 					resource.TestCheckResourceAttr(dataCenterServerResourceName, "server_address", dataCenterServerAddress),
@@ -131,8 +131,8 @@ func testCheckIncapsulaDataCenterServerExists(name string) resource.TestCheckFun
 	}
 }
 
-func testAccCheckIncapsulaDataCenterServerConfigBasic() string {
-	return testAccCheckIncapsulaDataCenterConfigBasic() + fmt.Sprintf(`
+func testAccCheckIncapsulaDataCenterServerConfigBasic(t *testing.T) string {
+	return testAccCheckIncapsulaDataCenterConfigBasic(t) + fmt.Sprintf(`
 resource "incapsula_data_center_server" "testacc-terraform-data-center-server" {
   dc_id = incapsula_data_center.testacc-terraform-data-center.id
   site_id = incapsula_site.testacc-terraform-site.id

--- a/incapsula/resource_data_center_test.go
+++ b/incapsula/resource_data_center_test.go
@@ -19,7 +19,7 @@ func TestAccIncapsulaDataCenter_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckIncapsulaDataCenterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIncapsulaDataCenterConfigBasic(),
+				Config: testAccCheckIncapsulaDataCenterConfigBasic(t),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckIncapsulaDataCenterExists(dataCenterResourceName),
 					resource.TestCheckResourceAttr(dataCenterResourceName, "name", dataCenterName),
@@ -146,8 +146,8 @@ func testCheckIncapsulaDataCenterExists(name string) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckIncapsulaDataCenterConfigBasic() string {
-	return testAccCheckIncapsulaSiteConfigBasic(testAccDomain) + fmt.Sprintf(`
+func testAccCheckIncapsulaDataCenterConfigBasic(t *testing.T) string {
+	return testAccCheckIncapsulaSiteConfigBasic(GenerateTestDomain(t)) + fmt.Sprintf(`
 resource "incapsula_data_center" "testacc-terraform-data-center" {
   site_id = "${incapsula_site.testacc-terraform-site.id}"
   name = "%s"

--- a/incapsula/resource_incap_rule_test.go
+++ b/incapsula/resource_incap_rule_test.go
@@ -19,7 +19,7 @@ func TestAccIncapsulaIncapRule_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckIncapsulaIncapRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIncapsulaIncapRuleConfigBasic(),
+				Config: testAccCheckIncapsulaIncapRuleConfigBasic(t),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckIncapsulaIncapRuleExists(incapRuleResourceName),
 					resource.TestCheckResourceAttr(incapRuleResourceName, "name", incapRuleName),
@@ -114,8 +114,8 @@ func testCheckIncapsulaIncapRuleExists(name string) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckIncapsulaIncapRuleConfigBasic() string {
-	return testAccCheckIncapsulaSiteConfigBasic(testAccDomain) + fmt.Sprintf(`
+func testAccCheckIncapsulaIncapRuleConfigBasic(t *testing.T) string {
+	return testAccCheckIncapsulaSiteConfigBasic(GenerateTestDomain(t)) + fmt.Sprintf(`
 resource "incapsula_incap_rule" "testacc-terraform-incap-rule" {
   name = "%s"
   site_id = "${incapsula_site.testacc-terraform-site.id}"

--- a/incapsula/resource_security_rule_exception_test.go
+++ b/incapsula/resource_security_rule_exception_test.go
@@ -23,7 +23,7 @@ func testAccCheckSecurityRuleExceptionCreateValidRule(t *testing.T) {
 		CheckDestroy: testAccCheckSecurityRuleExceptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckACLSecurityRuleExceptionGoodConfigBlacklistedCountries(),
+				Config: testAccCheckACLSecurityRuleExceptionGoodConfigBlacklistedCountries(t),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckSecurityRuleExceptionExists(securityRuleExceptionResourceNameBlacklistedCountries),
 					resource.TestCheckResourceAttr(securityRuleExceptionResourceNameBlacklistedCountries, "name", securityRuleExceptionNameBlacklistedCountries),
@@ -46,7 +46,7 @@ func testAccCheckSecurityRuleExceptionCreateInvalidRuleID(t *testing.T) {
 		CheckDestroy: testAccCheckSecurityRuleExceptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckACLSecurityRuleExceptionInvalidRuleIDBlacklistedCountries(),
+				Config: testAccCheckACLSecurityRuleExceptionInvalidRuleIDBlacklistedCountries(t),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckSecurityRuleExceptionExists(securityRuleExceptionResourceNameBlacklistedCountries),
 					resource.TestCheckResourceAttr(securityRuleExceptionResourceNameBlacklistedCountries, "name", securityRuleExceptionNameBlacklistedCountries),
@@ -69,7 +69,7 @@ func testAccCheckSecurityRuleExceptionCreateInvalidParams(t *testing.T) {
 		CheckDestroy: testAccCheckSecurityRuleExceptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckACLSecurityRuleExceptionInvalidParamBlacklistedCountries(),
+				Config: testAccCheckACLSecurityRuleExceptionInvalidParamBlacklistedCountries(t),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckSecurityRuleExceptionExists(securityRuleExceptionResourceNameBlacklistedCountries),
 					resource.TestCheckResourceAttr(securityRuleExceptionResourceNameBlacklistedCountries, "name", securityRuleExceptionNameBlacklistedCountries),
@@ -157,8 +157,8 @@ func testAccStateSecurityRuleExceptionID(s *terraform.State) (string, error) {
 }
 
 // Good Security Rule Exception configs
-func testAccCheckACLSecurityRuleExceptionGoodConfigBlacklistedCountries() string {
-	return testAccCheckIncapsulaSiteConfigBasic(testAccDomain) + fmt.Sprintf("%s%s", `
+func testAccCheckACLSecurityRuleExceptionGoodConfigBlacklistedCountries(t *testing.T) string {
+	return testAccCheckIncapsulaSiteConfigBasic(GenerateTestDomain(t)) + fmt.Sprintf("%s%s", `
 resource "incapsula_security_rule_exception" "example-waf-blacklisted-countries-rule-exception" {
   site_id = "${incapsula_site.example-site.id}"
   rule_id = "api.acl.blacklisted_countries"
@@ -171,8 +171,8 @@ resource "incapsula_security_rule_exception" "example-waf-blacklisted-countries-
 }
 
 // Bad Security Rule Exception configs
-func testAccCheckACLSecurityRuleExceptionInvalidRuleIDBlacklistedCountries() string {
-	return testAccCheckIncapsulaSiteConfigBasic(testAccDomain) + fmt.Sprintf("%s%s", `
+func testAccCheckACLSecurityRuleExceptionInvalidRuleIDBlacklistedCountries(t *testing.T) string {
+	return testAccCheckIncapsulaSiteConfigBasic(GenerateTestDomain(t)) + fmt.Sprintf("%s%s", `
 resource "incapsula_security_rule_exception" "example-waf-blacklisted-countries-rule-exception" {
   site_id = "${incapsula_site.example-site.id}"
   rule_id = "bad_rule_id"
@@ -184,8 +184,8 @@ resource "incapsula_security_rule_exception" "example-waf-blacklisted-countries-
 	)
 }
 
-func testAccCheckACLSecurityRuleExceptionInvalidParamBlacklistedCountries() string {
-	return testAccCheckIncapsulaSiteConfigBasic(testAccDomain) + fmt.Sprintf("%s%s", `
+func testAccCheckACLSecurityRuleExceptionInvalidParamBlacklistedCountries(t *testing.T) string {
+	return testAccCheckIncapsulaSiteConfigBasic(GenerateTestDomain(t)) + fmt.Sprintf("%s%s", `
 resource "incapsula_security_rule_exception" "example-waf-blacklisted-countries-rule-exception" {
   site_id = "${incapsula_site.example-site.id}"
   rule_id = "api.acl.blacklisted_countries"

--- a/incapsula/resource_site.go
+++ b/incapsula/resource_site.go
@@ -105,6 +105,7 @@ func resourceSite() *schema.Resource {
 			"seal_location": {
 				Description: "api.seal_location.bottom_left | api.seal_location.none | api.seal_location.right_bottom | api.seal_location.right | api.seal_location.left | api.seal_location.bottom_right | api.seal_location.bottom.",
 				Type:        schema.TypeString,
+				Default:     "api.seal_location.none",
 				Optional:    true,
 			},
 			"domain_redirect_to_full": {

--- a/incapsula/resource_waf_security_rule_test.go
+++ b/incapsula/resource_waf_security_rule_test.go
@@ -23,7 +23,7 @@ func testAccCheckWAFSecurityRuleCreateGoodConfigBackdoor(t *testing.T) {
 		CheckDestroy: testAccCheckWAFSecurityRuleDestroyBackdoor,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckWAFSecurityRuleGoodConfigBackdoor(),
+				Config: testAccCheckWAFSecurityRuleGoodConfigBackdoor(t),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckWAAFSecurityRuleExists(wafSecurityRuleResourceNameBackdoor),
 					resource.TestCheckResourceAttr(wafSecurityRuleResourceNameBackdoor, "name", wafSecurityRuleNameBackdoor),
@@ -46,7 +46,7 @@ func testAccCheckWAFSecurityRuleCreateGoodConfigDDoS(t *testing.T) {
 		CheckDestroy: testAccCheckWAFSecurityRuleDestroyDDoS,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckWAFSecurityRuleGoodConfigDDoS(),
+				Config: testAccCheckWAFSecurityRuleGoodConfigDDoS(t),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckWAAFSecurityRuleExists(wafSecurityRuleResourceNameDDoS),
 					resource.TestCheckResourceAttr(wafSecurityRuleResourceNameDDoS, "name", wafSecurityRuleResourceNameDDoS),
@@ -69,7 +69,7 @@ func testAccCheckWAFSecurityRuleCreateGoodConfigBots(t *testing.T) {
 		CheckDestroy: testAccCheckWAFSecurityRuleDestroyBots,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckWAFSecurityRuleGoodConfigBots(),
+				Config: testAccCheckWAFSecurityRuleGoodConfigBots(t),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckWAAFSecurityRuleExists(wafSecurityRuleResourceNameBotAccessControl),
 					resource.TestCheckResourceAttr(wafSecurityRuleResourceNameBotAccessControl, "name", wafSecurityRuleResourceNameBotAccessControl),
@@ -92,7 +92,7 @@ func testAccCheckWAFSecurityRuleCreateBadConfigBackdoor(t *testing.T) {
 		CheckDestroy: testAccCheckWAFSecurityRuleDestroyBackdoor,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckWAFSecurityRuleBadConfigBackdoor(),
+				Config: testAccCheckWAFSecurityRuleBadConfigBackdoor(t),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckWAAFSecurityRuleExists(wafSecurityRuleResourceNameBackdoor),
 					resource.TestCheckResourceAttr(wafSecurityRuleResourceNameBackdoor, "name", wafSecurityRuleResourceNameBackdoor),
@@ -115,7 +115,7 @@ func testAccCheckWAFSecurityRuleCreateBadConfigDDoS(t *testing.T) {
 		CheckDestroy: testAccCheckWAFSecurityRuleDestroyDDoS,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckWAFSecurityRuleBadConfigDDoS(),
+				Config: testAccCheckWAFSecurityRuleBadConfigDDoS(t),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckWAAFSecurityRuleExists(wafSecurityRuleResourceNameDDoS),
 					resource.TestCheckResourceAttr(wafSecurityRuleResourceNameDDoS, "name", wafSecurityRuleResourceNameDDoS),
@@ -138,7 +138,7 @@ func testAccCheckWAFSecurityRuleCreateBadConfigBots(t *testing.T) {
 		CheckDestroy: testAccCheckWAFSecurityRuleDestroyBots,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckWAFSecurityRuleBadConfigBots(),
+				Config: testAccCheckWAFSecurityRuleBadConfigBots(t),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckWAAFSecurityRuleExists(wafSecurityRuleResourceNameBotAccessControl),
 					resource.TestCheckResourceAttr(wafSecurityRuleResourceNameBotAccessControl, "name", wafSecurityRuleNameBots),
@@ -222,8 +222,8 @@ func testCheckWAAFSecurityRuleExists(name string) resource.TestCheckFunc {
 }
 
 // Good and bad WAF Security Rule configs
-func testAccCheckWAFSecurityRuleGoodConfigBackdoor() string {
-	return testAccCheckIncapsulaSiteConfigBasic(testAccDomain) + fmt.Sprintf("%s%s%s", `
+func testAccCheckWAFSecurityRuleGoodConfigBackdoor(t *testing.T) string {
+	return testAccCheckIncapsulaSiteConfigBasic(GenerateTestDomain(t)) + fmt.Sprintf("%s%s%s", `
 resource "incapsula_waf_security_rule" "example-waf-backdoor-rule" {
   site_id = "${incapsula_site.example-site.id}"
   rule_id = "api.threats.backdoor"
@@ -232,8 +232,8 @@ resource "incapsula_waf_security_rule" "example-waf-backdoor-rule" {
 	)
 }
 
-func testAccCheckWAFSecurityRuleGoodConfigDDoS() string {
-	return testAccCheckIncapsulaSiteConfigBasic(testAccDomain) + fmt.Sprintf("%s%s%s", `
+func testAccCheckWAFSecurityRuleGoodConfigDDoS(t *testing.T) string {
+	return testAccCheckIncapsulaSiteConfigBasic(GenerateTestDomain(t)) + fmt.Sprintf("%s%s%s", `
 resource "incapsula_waf_security_rule" "example-waf-ddos-rule" {
   site_id = "${incapsula_site.example-site.id}"
   rule_id = "api.threats.ddos"
@@ -243,8 +243,8 @@ resource "incapsula_waf_security_rule" "example-waf-ddos-rule" {
 	)
 }
 
-func testAccCheckWAFSecurityRuleGoodConfigBots() string {
-	return testAccCheckIncapsulaSiteConfigBasic(testAccDomain) + fmt.Sprintf("%s%s%s", `
+func testAccCheckWAFSecurityRuleGoodConfigBots(t *testing.T) string {
+	return testAccCheckIncapsulaSiteConfigBasic(GenerateTestDomain(t)) + fmt.Sprintf("%s%s%s", `
 resource "incapsula_waf_security_rule" "example-waf-bot-access-control-rule" {
   site_id = "${incapsula_site.example-site.id}"
   rule_id = "api.threats.bot_access_control"
@@ -254,8 +254,8 @@ resource "incapsula_waf_security_rule" "example-waf-bot-access-control-rule" {
 	)
 }
 
-func testAccCheckWAFSecurityRuleBadConfigBackdoor() string {
-	return testAccCheckIncapsulaSiteConfigBasic(testAccDomain) + fmt.Sprintf("%s%s%s", `
+func testAccCheckWAFSecurityRuleBadConfigBackdoor(t *testing.T) string {
+	return testAccCheckIncapsulaSiteConfigBasic(GenerateTestDomain(t)) + fmt.Sprintf("%s%s%s", `
 resource "incapsula_waf_security_rule" "example-waf-backdoor-rule" {
   site_id = "${incapsula_site.example-site.id}"
   rule_id = "api.threats.backdoor"
@@ -264,8 +264,8 @@ resource "incapsula_waf_security_rule" "example-waf-backdoor-rule" {
 	)
 }
 
-func testAccCheckWAFSecurityRuleBadConfigDDoS() string {
-	return testAccCheckIncapsulaSiteConfigBasic(testAccDomain) + fmt.Sprintf("%s%s%s", `
+func testAccCheckWAFSecurityRuleBadConfigDDoS(t *testing.T) string {
+	return testAccCheckIncapsulaSiteConfigBasic(GenerateTestDomain(t)) + fmt.Sprintf("%s%s%s", `
 resource "incapsula_waf_security_rule" "example-waf-ddos-rule" {
   site_id = "${incapsula_site.example-site.id}"
   rule_id = "api.threats.ddos"
@@ -275,8 +275,8 @@ resource "incapsula_waf_security_rule" "example-waf-ddos-rule" {
 	)
 }
 
-func testAccCheckWAFSecurityRuleBadConfigBots() string {
-	return testAccCheckIncapsulaSiteConfigBasic(testAccDomain) + fmt.Sprintf("%s%s%s", `
+func testAccCheckWAFSecurityRuleBadConfigBots(t *testing.T) string {
+	return testAccCheckIncapsulaSiteConfigBasic(GenerateTestDomain(t)) + fmt.Sprintf("%s%s%s", `
 resource "incapsula_waf_security_rule" "example-waf-bot-access-control-rule" {
   site_id = "${incapsula_site.example-site.id}"
   rule_id = "api.threats.bot_access_control"


### PR DESCRIPTION
Fixed the following:

1. Send TF provider version as HTTP header.
2. Send api_id and api_key as HTTP headers (instead of query/body parameters)
3. Fix seal_location to have default value (avoiding non-empty plan after apply).
4. Allow multiple component tests account (using api id as site's sub-domain and account's email prefix).