### PR TITLE
formatting parameters with %t fails if the values are strings, not bool

### DIFF
--- a/incapsula/resource_site.go
+++ b/incapsula/resource_site.go
@@ -626,10 +626,11 @@ func updateAdditionalSiteProperties(client *Client, d *schema.ResourceData) erro
 		param := updateParams[i]
 
 		if d.HasChange(param) && d.Get(param) != "" {
-			log.Printf("[INFO] Updating Incapsula site param (%s) with value (%s) for site_id: %s\n", param, fmt.Sprintf("%t", d.Get(param)), d.Id())
-			_, err := client.UpdateSite(d.Id(), param, fmt.Sprintf("%t", d.Get(param)))
+			value := fmt.Sprintf("%v", d.Get(param))
+			log.Printf("[INFO] Updating Incapsula site param (%s) with value (%s) for site_id: %s\n", param, value, d.Id())
+			_, err := client.UpdateSite(d.Id(), param, value)
 			if err != nil {
-				log.Printf("[ERROR] Could not update Incapsula site param (%s) with value (%s) for site_id: %s %s\n", param, fmt.Sprintf("%t", d.Get(param)), d.Id(), err)
+				log.Printf("[ERROR] Could not update Incapsula site param (%s) with value (%s) for site_id: %s %s\n", param, value, d.Id(), err)
 				return err
 			}
 		}


### PR DESCRIPTION
This showed up when I was trying to create an `incapsula_site` resource with dns domain validation. Something like this:

```hcl
resource "incapsula_site" "this" {
  domain                 = var.public_domain_name
  send_site_setup_emails = false
  force_ssl              = true
  ignore_ssl             = true
  domain_validation      = "dns"
  site_ip                = var.backend_domain_name
}
```

It gives this error:
```
Error: Error from Incapsula service when updating site for siteID xxxxxx: {"res":6002,"res_message":"Invalid configuration parameter value","debug_info":{"domain_validation":"%!t(string\u003ddns)","id-info":"999999"}}
```

I looked at the `resource_site.go` and saw there was an sprintf with the format of `"%t"` but with strings being passed in. `%t` will only work with bool types. But `%v` seems more appropriate because it will work with strings but also will give `"true"` or `"false"` when formatting a bool, just like `%t`. See [golang docs for fmt](https://pkg.go.dev/fmt)