### PR TITLE
Update resource_api_security_site_config.go

### DIFF
--- a/incapsula/resource_api_security_site_config.go
+++ b/incapsula/resource_api_security_site_config.go
@@ -36,7 +36,7 @@ func resourceApiSecuritySiteConfig() *schema.Resource {
 			"is_automatic_discovery_api_integration_enabled": {
 				Description: "Parameter shows whether automatic API discovery is enabled",
 				Type:        schema.TypeBool,
-				Required:    true,
+				Required:    false,
 			},
 
 			//Optional


### PR DESCRIPTION
This is to address an issue whereby an error is thrown regarding licensing when a boolean value is passed to the is_automatic_discovery_api_integration_enabled parameter. If we pass "null" we can allow customers to onboard successfully.

_incapsula_api_security_site_config.demo-terraform-api-security-site-config: Creating...

Error: Error status code 400 from Incapsula service when updating api-security site configuration: {"value":"Your current subscription license does not support Automatic Integration. Please upgrade your subscription license.","isError":true}_

I have tested this against the API directly successfully:

https://api.imperva.com/api-security/config/site/xxxxx

{
  "siteId": 4xxx,
  "accountId": 1xxx,
  "siteName": "www.sitexxx.com.au",
  "apiOnlySite": true,
  "nonApiRequestViolationAction": "ALERT_ONLY",
  "lastModified": 1556735907,
  "violationActions": {
    "missingParamViolationAction": "ALERT_ONLY",
    "invalidParamValueViolationAction": "ALERT_ONLY",
    "invalidParamNameViolationAction": "ALERT_ONLY",
    "invalidUrlViolationAction": "ALERT_ONLY",
    "invalidMethodViolationAction": "ALERT_ONLY"
  },
  "discoveryEnabled": false,
  "discoveryExcludeBasePath": [],
  "discoveryIncludeBasePath": [],
  **"isAutomaticDiscoveryApiIntegrationEnabled": null**
}

result:

{
	"value": {
		"siteId": 4xxx
	},
	"isError": false
}

this will allow us to specify is_automatic_discovery_api_integration_enabled = null and succeed in using this resource with customer without API Security Add-On