### PR TITLE
Make `invalid_param_name_violation_action` deprecated in the `incapsu…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.8.6
+
+* Make `invalid_param_name_violation_action` deprecated in the `incapsula_api_security_site_config` resource
+* Make `invalid_param_name_violation_action` deprecated in the `incapsula_api_security_api_config` resource
+
 ## 3.8.5 (Aug 31, 2022)
 
 BUG FIXES:

--- a/incapsula/resource_api_security_api_config.go
+++ b/incapsula/resource_api_security_api_config.go
@@ -90,8 +90,7 @@ func resourceApiSecurityApiConfig() *schema.Resource {
 				Optional:     true,
 				Default:      "DEFAULT",
 				ValidateFunc: validation.StringInSlice([]string{"ALERT_ONLY", "BLOCK_REQUEST", "BLOCK_USER", "BLOCK_IP", "IGNORE", "DEFAULT"}, false),
-				Deprecated:   "this field is deprecated",
-			},
+				Deprecated:   "invalid_param_name_violation_action field is deprecated"},
 
 			"description": {
 				Description: "A description that will help recognize the API in the dashboard",

--- a/incapsula/resource_api_security_api_config.go
+++ b/incapsula/resource_api_security_api_config.go
@@ -90,6 +90,7 @@ func resourceApiSecurityApiConfig() *schema.Resource {
 				Optional:     true,
 				Default:      "DEFAULT",
 				ValidateFunc: validation.StringInSlice([]string{"ALERT_ONLY", "BLOCK_REQUEST", "BLOCK_USER", "BLOCK_IP", "IGNORE", "DEFAULT"}, false),
+				Deprecated:   "this field is deprecated",
 			},
 
 			"description": {

--- a/incapsula/resource_api_security_endpoint_config.go
+++ b/incapsula/resource_api_security_endpoint_config.go
@@ -83,6 +83,7 @@ func resourceApiSecurityEndpointConfig() *schema.Resource {
 				Optional:     true,
 				Default:      "DEFAULT",
 				ValidateFunc: validation.StringInSlice([]string{"ALERT_ONLY", "BLOCK_REQUEST", "BLOCK_USER", "BLOCK_IP", "IGNORE", "DEFAULT"}, false),
+				Deprecated:   "invalid_param_name_violation_action field is deprecated",
 			},
 		},
 	}

--- a/incapsula/resource_api_security_site_config.go
+++ b/incapsula/resource_api_security_site_config.go
@@ -74,6 +74,7 @@ func resourceApiSecuritySiteConfig() *schema.Resource {
 				Optional:     true,
 				ValidateFunc: validation.StringInSlice([]string{"ALERT_ONLY", "BLOCK_REQUEST", "BLOCK_USER", "BLOCK_IP", "IGNORE"}, false),
 				Default:      "ALERT_ONLY",
+				Deprecated:   "invalid_param_name_violation_action field is deprecated",
 			},
 			"is_api_only_site": {
 				Description: "Apply positive security model for all traffic on the site. Applying the positive security model for all traffic on the site may lead to undesired request blocking.",

--- a/website/docs/r/api_security_api_config.html.markdown
+++ b/website/docs/r/api_security_api_config.html.markdown
@@ -21,7 +21,6 @@ resource "incapsula_api_security_api_config" "demo-terraform-api-security-api-co
 	invalid_method_violation_action = "BLOCK_USER"
 	missing_param_violation_action = "BLOCK_IP"
 	invalid_param_value_violation_action = "BLOCK_REQUEST"
-	invalid_param_name_violation_action = "ALERT_ONLY"
 	description = "your site API description"
 	base_path = "/base/path"
 }

--- a/website/docs/r/api_security_endpoint_config.html.markdown
+++ b/website/docs/r/api_security_endpoint_config.html.markdown
@@ -18,7 +18,6 @@ resource "incapsula_api_security_endpoint_config" "demo-api-security-endpoint-co
     api_id = incapsula_api_security_api_config.demo_api_security_api_config.id
     path = "/endpoint/unit/{id}"
 	method = "GET"
-	invalid_param_name_violation_action = "BLOCK_REQUEST"
 	invalid_param_value_violation_action = "ALERT_ONLY"
 	missing_param_violation_action = "BLOCK_IP"
 }

--- a/website/docs/r/api_security_site_config.html.markdown
+++ b/website/docs/r/api_security_site_config.html.markdown
@@ -19,7 +19,7 @@ resource "incapsula_api_security_site_config" "demo-terraform-api-security-site-
   	non_api_request_violation_action = "ALERT_ONLY"
   	invalid_url_violation_action = "BLOCK_IP"
   	invalid_method_violation_action = "BLOCK_REQUEST"
-  	missing_param_violation_action = "BLOCK_REQUEST"
+  	missing_param_violation_action = "IGNORE"
   	invalid_param_value_violation_action = "IGNORE"
   	invalid_param_name_violation_action = "ALERT_ONLY"
 }

--- a/website/docs/r/api_security_site_config.html.markdown
+++ b/website/docs/r/api_security_site_config.html.markdown
@@ -21,7 +21,6 @@ resource "incapsula_api_security_site_config" "demo-terraform-api-security-site-
   	invalid_method_violation_action = "BLOCK_REQUEST"
   	missing_param_violation_action = "IGNORE"
   	invalid_param_value_violation_action = "IGNORE"
-  	invalid_param_name_violation_action = "ALERT_ONLY"
 }
 ```
 

--- a/website/docs/r/api_security_site_config.html.markdown
+++ b/website/docs/r/api_security_site_config.html.markdown
@@ -19,7 +19,7 @@ resource "incapsula_api_security_site_config" "demo-terraform-api-security-site-
   	non_api_request_violation_action = "ALERT_ONLY"
   	invalid_url_violation_action = "BLOCK_IP"
   	invalid_method_violation_action = "BLOCK_REQUEST"
-  	missing_param_violation_action = "DEFAULT"
+  	missing_param_violation_action = "BLOCK_REQUEST"
   	invalid_param_value_violation_action = "IGNORE"
   	invalid_param_name_violation_action = "ALERT_ONLY"
 }


### PR DESCRIPTION
…la_api_security_site_config` and `incapsula_api_security_api_config` resource