### PR TITLE
Cwms 2008

### DIFF
--- a/incapsula/client.go
+++ b/incapsula/client.go
@@ -27,6 +27,7 @@ type Client struct {
 	config          *Config
 	httpClient      *http.Client
 	providerVersion string
+	accountStatus   *AccountStatusResponse
 }
 
 // NewClient creates a new client with the provided configuration

--- a/incapsula/client_account.go
+++ b/incapsula/client_account.go
@@ -65,6 +65,7 @@ type AccountStatusResponse struct {
 	Email       string `json:"email"`
 	PlanID      string `json:"plan_id"`
 	PlanName    string `json:"plan_name"`
+	AccountType string `json:"account_type"`
 	AccountID   int    `json:"account_id"`
 	UserName    string `json:"user_name"`
 	AccountName string `json:"account_name"`

--- a/incapsula/client_policy.go
+++ b/incapsula/client_policy.go
@@ -92,6 +92,9 @@ func (c *Client) AddPolicy(policySubmitted *PolicySubmitted) (*PolicyExtended, e
 	// Post form to Incapsula
 	log.Printf("[DEBUG] Incapsula Add Incap Policy JSON request: %s\n", string(policyJSON))
 	reqURL := fmt.Sprintf("%s/policies/v2/policies", c.config.BaseURLAPI)
+	if policySubmitted.AccountID != 0 {
+		reqURL = fmt.Sprintf("%s?caid=%d", reqURL, policySubmitted.AccountID)
+	}
 	resp, err := c.DoJsonRequestWithHeaders(http.MethodPost, reqURL, policyJSON, CreatePolicy)
 	if err != nil {
 		return nil, fmt.Errorf("Error from Incapsula service when adding Policy: %s", err)
@@ -120,11 +123,15 @@ func (c *Client) AddPolicy(policySubmitted *PolicySubmitted) (*PolicyExtended, e
 }
 
 // GetPolicy gets the policy
-func (c *Client) GetPolicy(policyID string) (*PolicyExtended, error) {
+func (c *Client) GetPolicy(policyID string, currentAccountId *int) (*PolicyExtended, error) {
 	log.Printf("[INFO] Getting Incapsula Policy: %s\n", policyID)
 
 	// Post form to Incapsula
 	reqURL := fmt.Sprintf("%s/policies/v2/policies/%s?extended=true", c.config.BaseURLAPI, policyID)
+	if currentAccountId != nil {
+		reqURL = fmt.Sprintf("%s&caid=%d", reqURL, *currentAccountId)
+	}
+
 	resp, err := c.DoJsonRequestWithHeaders(http.MethodGet, reqURL, nil, ReadPolicy)
 	if err != nil {
 		return nil, fmt.Errorf("Error from Incapsula service when reading Policy for ID %s: %s", policyID, err)
@@ -153,7 +160,7 @@ func (c *Client) GetPolicy(policyID string) (*PolicyExtended, error) {
 }
 
 // UpdatePolicy updates the Incapsula Policy
-func (c *Client) UpdatePolicy(policyID int, policySubmitted *PolicySubmitted) (*PolicyExtended, error) {
+func (c *Client) UpdatePolicy(policyID int, policySubmitted *PolicySubmitted, currentAccountId *int) (*PolicyExtended, error) {
 	log.Printf("[INFO] Updating Incapsula Policy with ID %d\n", policyID)
 
 	policyJSON, err := json.Marshal(policySubmitted)
@@ -164,6 +171,9 @@ func (c *Client) UpdatePolicy(policyID int, policySubmitted *PolicySubmitted) (*
 	// Post form to Incapsula
 	log.Printf("[DEBUG] Incapsula Update Incap Policy JSON request: %s\n", string(policyJSON))
 	reqURL := fmt.Sprintf("%s/policies/v2/policies/%d", c.config.BaseURLAPI, policyID)
+	if currentAccountId != nil {
+		reqURL = fmt.Sprintf("%s?caid=%d", reqURL, *currentAccountId)
+	}
 	resp, err := c.DoJsonRequestWithHeaders(http.MethodPut, reqURL, policyJSON, UpdatePolicy)
 	if err != nil {
 		return nil, fmt.Errorf("Error from Incapsula service when updating Policy: %s", err)
@@ -192,11 +202,14 @@ func (c *Client) UpdatePolicy(policyID int, policySubmitted *PolicySubmitted) (*
 }
 
 // DeletePolicy deletes a policy currently managed by Incapsula
-func (c *Client) DeletePolicy(policyID string) error {
+func (c *Client) DeletePolicy(policyID string, currentAccountId *int) error {
 	log.Printf("[INFO] Deleting Incapsula Policy for ID %s\n", policyID)
 
 	// Delete request to Incapsula
 	reqURL := fmt.Sprintf("%s/policies/v2/policies/%s", c.config.BaseURLAPI, policyID)
+	if currentAccountId != nil {
+		reqURL = fmt.Sprintf("%s?caid=%d", reqURL, *currentAccountId)
+	}
 	resp, err := c.DoJsonRequestWithHeaders(http.MethodDelete, reqURL, nil, DeletePolicy)
 	if err != nil {
 		return fmt.Errorf("Error from Incapsula service when deleting Policy with ID %s: %s", policyID, err)
@@ -301,7 +314,7 @@ func (c *Client) GetAllPoliciesForAccount(accountId string) (*[]Policy, error) {
 	log.Printf("[INFO] Getting All Incapsula Policies for account: %s\n", accountId)
 	//
 	// Post form to Incapsula
-	reqURL := fmt.Sprintf("%s/policies/v2/policies?extended=true", c.config.BaseURLAPI)
+	reqURL := fmt.Sprintf("%s/policies/v2/policies?caid=%s&extended=true", c.config.BaseURLAPI, accountId)
 	resp, err := c.DoJsonRequestWithHeaders(http.MethodGet, reqURL, nil, ReadPoliciesAll)
 	if err != nil {
 		return nil, fmt.Errorf("[ERROR] Error from Incapsula service when reading All Policies for Account ID %s: %s", accountId, err)

--- a/incapsula/config.go
+++ b/incapsula/config.go
@@ -69,7 +69,8 @@ func (c *Config) Client() (interface{}, error) {
 	client := NewClient(c)
 
 	// Verify client credentials
-	_, err := client.Verify()
+	accountStatusResponse, err := client.Verify()
+	client.accountStatus = accountStatusResponse
 	if err != nil {
 		return nil, err
 	}

--- a/incapsula/resource_account_policy_association.go
+++ b/incapsula/resource_account_policy_association.go
@@ -68,7 +68,7 @@ func resourceAccountPolicyAssociationUpdate(d *schema.ResourceData, m interface{
 		}
 
 		//to update WAF policy
-		policyGetResponse, err := client.GetPolicy(wafPolicyIDStr)
+		policyGetResponse, err := client.GetPolicy(wafPolicyIDStr, &accountID)
 		if err != nil {
 			log.Printf("[ERROR] Could not get Incapsula policy: %s - %s\n", wafPolicyIDStr, err)
 			return err
@@ -110,7 +110,7 @@ func resourceAccountPolicyAssociationDelete(d *schema.ResourceData, m interface{
 	nonMandatoryPolicyIdList := (d.Get("default_non_mandatory_policy_ids").(*schema.Set).List())
 	for _, policy := range nonMandatoryPolicyIdList {
 		policyIdStr := fmt.Sprint(policy)
-		policyGetResponse, err := client.GetPolicy(policyIdStr)
+		policyGetResponse, err := client.GetPolicy(policyIdStr, &accountID)
 		if err != nil {
 			log.Printf("[ERROR] Could not get Incapsula policy: %s - %s\n", policyIdStr, err)
 			return err
@@ -228,7 +228,7 @@ func removePolicy(policy Policy, accountId int, client Client) error {
 			updatedDefaultPolicyConfigList = append(updatedDefaultPolicyConfigList, defaultPolicyConfig)
 		}
 	}
-	return upsertPolicy(policy, updatedDefaultPolicyConfigList, client)
+	return upsertPolicy(policy, updatedDefaultPolicyConfigList, client, accountId)
 }
 
 func updatePolicy(policy Policy, accountId int, client Client) error {
@@ -244,10 +244,10 @@ func updatePolicy(policy Policy, accountId int, client Client) error {
 
 	newDefaultConfig := DefaultPolicyConfig{AccountID: accountId, AssetType: WEBSITE}
 	updatedDefaultPolicyConfigList := append(policy.DefaultPolicyConfig, newDefaultConfig)
-	return upsertPolicy(policy, updatedDefaultPolicyConfigList, client)
+	return upsertPolicy(policy, updatedDefaultPolicyConfigList, client, accountId)
 }
 
-func upsertPolicy(policy Policy, updatedDefaultPolicyConfigList []DefaultPolicyConfig, client Client) error {
+func upsertPolicy(policy Policy, updatedDefaultPolicyConfigList []DefaultPolicyConfig, client Client, accountId int) error {
 	policyUpserted := PolicySubmitted{
 		Name:                policy.Name,
 		Description:         policy.Description,
@@ -257,7 +257,7 @@ func upsertPolicy(policy Policy, updatedDefaultPolicyConfigList []DefaultPolicyC
 		PolicySettings:      policy.PolicySettings,
 		DefaultPolicyConfig: updatedDefaultPolicyConfigList,
 	}
-	_, err := client.UpdatePolicy(policy.ID, &policyUpserted)
+	_, err := client.UpdatePolicy(policy.ID, &policyUpserted, &accountId)
 
 	if err != nil {
 		log.Printf("[ERROR] Could not update Incapsula policy: %s - %s\n", policyUpserted.Name, err)


### PR DESCRIPTION
adding account status response to the client object. this allows to have the account context on any client request.
adding account type to the account status response
adding current account to the policy actions.
this allows a reseller to manage its accounts' policies