### PR TITLE
#UM-8793 - wrong resource name definition for "incapsula_application_delivery"

### DIFF
--- a/website/docs/r/application_delivery.html.markdown
+++ b/website/docs/r/application_delivery.html.markdown
@@ -15,7 +15,7 @@ Note that destroy action will return the configuration to the default values.
 ### Basic Usage - Application Delivery
 
 ```hcl
-resource "resource_application_delivery" "example_application_delivery" {
+resource "incapsula_application_delivery" "example_application_delivery" {
 	site_id = incapsula_site.testacc-terraform-site.id
 	file_compression            = true
 	minify_css                  = true


### PR DESCRIPTION
incapsula_application_delivery resource was mistakenly named resource_application_delivery in the docs.