### PR TITLE
feat: add site ID lookup by website domain

### DIFF
--- a/incapsula/client_site.go
+++ b/incapsula/client_site.go
@@ -387,14 +387,13 @@ func (c *Client) DeleteSite(domain string, siteID int) error {
 }
 
 func (c *Client) ListAllSites() (*SiteListResponse, error) {
-	log.Printf("[INFO] Getting Incapsula sites for account %s", "")
+	log.Print("[INFO] Getting Incapsula sites for all accounts")
 
 	// Post form to Incapsula
-	// values := url.Values{"account_id": {strconv.Itoa(AccountID)}}
 	reqURL := fmt.Sprintf("%s/%s", c.config.BaseURL, endpointSiteList)
 	resp, err := c.PostFormWithHeaders(reqURL, nil, ReadSite)
 	if err != nil {
-		return nil, fmt.Errorf("Error getting site list for for account %s", "AccountID", err)
+		return nil, fmt.Errorf("Error getting site list for all accounts %s", err)
 	}
 
 	// Read the body
@@ -408,7 +407,7 @@ func (c *Client) ListAllSites() (*SiteListResponse, error) {
 	var siteListsResponse SiteListResponse
 	err = json.Unmarshal([]byte(responseBody), &siteListsResponse)
 	if err != nil {
-		return nil, fmt.Errorf("Error parsing site list JSON response for account %s  %s", "AccountID", err)
+		return nil, fmt.Errorf("Error parsing site list JSON response for all accounts %s", err)
 	}
 
 	var resString string
@@ -421,7 +420,7 @@ func (c *Client) ListAllSites() (*SiteListResponse, error) {
 
 	// Look at the response status code from Incapsula
 	if resString != "0" {
-		return &siteListsResponse, fmt.Errorf("Error from Incapsula service when getting site list for account %s %s", "AccountID", string(responseBody))
+		return &siteListsResponse, fmt.Errorf("Error from Incapsula service when getting site list for all accounts %s", string(responseBody))
 	}
 
 	return &siteListsResponse, nil
@@ -435,7 +434,7 @@ func (c *Client) ListAllSitesInAccount(AccountID string) (*SiteListResponse, err
 	reqURL := fmt.Sprintf("%s/%s", c.config.BaseURL, endpointSiteList)
 	resp, err := c.PostFormWithHeaders(reqURL, values, ReadSite)
 	if err != nil {
-		return nil, fmt.Errorf("Error getting site list for for account %s, %v", AccountID, err)
+		return nil, fmt.Errorf("Error getting site list for account %s, %v", AccountID, err)
 	}
 
 	// Read the body

--- a/incapsula/data_source_site.go
+++ b/incapsula/data_source_site.go
@@ -14,7 +14,6 @@ func dataSourceSite() *schema.Resource {
 		Description: "Provides data about user Account",
 
 		Schema: map[string]*schema.Schema{
-			// Computed Attributes
 			"account_id": {
 				Type:        schema.TypeString,
 				Description: "Account ID",
@@ -25,11 +24,6 @@ func dataSourceSite() *schema.Resource {
 				Description: "site url to find ID of",
 				Required:    true,
 			},
-			// "site_id": {
-			// 	Type:        schema.TypeString,
-			// 	Description: "site ID",
-			// 	Computed:    true,
-			// },
 		},
 	}
 }

--- a/incapsula/data_source_site.go
+++ b/incapsula/data_source_site.go
@@ -1,0 +1,69 @@
+package incapsula
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceSite() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceSiteRead,
+		Description: "Provides data about user Account",
+
+		Schema: map[string]*schema.Schema{
+			// Computed Attributes
+			"account_id": {
+				Type:        schema.TypeString,
+				Description: "Account ID",
+				Optional:    true,
+			},
+			"site_url": {
+				Type:        schema.TypeString,
+				Description: "site url to find ID of",
+				Required:    true,
+			},
+			// "site_id": {
+			// 	Type:        schema.TypeString,
+			// 	Description: "site ID",
+			// 	Computed:    true,
+			// },
+		},
+	}
+}
+
+func dataSourceSiteRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*Client)
+
+	var accountStatusResponse *SiteListResponse
+	var err error
+	if accountID, ok := d.GetOk("account_id"); ok {
+		accountStatusResponse, err = client.ListAllSitesInAccount(accountID.(string))
+		if err != nil {
+			return diag.Errorf("Error listing all sites: %v", err)
+		}
+	} else {
+		accountStatusResponse, err = client.ListAllSites()
+		if err != nil {
+			return diag.Errorf("Error listing all sites: %v", err)
+		}
+	}
+
+	foundSite := false
+	for i := range accountStatusResponse.Sites {
+		site := accountStatusResponse.Sites[i]
+		if site.Domain == d.Get("site_url") {
+			d.SetId(strconv.Itoa(site.SiteID))
+			d.Set("account_id", strconv.Itoa(site.AccountID))
+			foundSite = true
+		}
+	}
+
+	if !foundSite {
+		return diag.Errorf("Error finding site: %v, this domain name does not exist in account: %v", d.Get("site_url"), d.Get("account_id"))
+	}
+
+	return nil
+}

--- a/incapsula/provider.go
+++ b/incapsula/provider.go
@@ -84,6 +84,7 @@ func Provider() *schema.Provider {
 			"incapsula_data_center":      dataSourceDataCenter(),
 			"incapsula_account_data":     dataSourceAccount(),
 			"incapsula_client_apps_data": dataSourceClientApps(),
+			"incapsula_site":             dataSourceSite(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{


### PR DESCRIPTION
This adds a data source "incapsula_site" for looking up incapsula sites via domain name.

It grabs a list of all sites in the specified account and loops through looking for a matching domain name.