### PR TITLE
Fix/ on the delete delivery API test

### DIFF
--- a/incapsula/resource_application_delivery.go
+++ b/incapsula/resource_application_delivery.go
@@ -422,9 +422,18 @@ func resourceApplicationDeliveryDelete(d *schema.ResourceData, m interface{}) er
 		},
 	}
 
+	compression := Compression{
+		FileCompression:  true,
+		CompressionType:  "GZIP",
+		MinifyJs:         true,
+		MinifyCss:        true,
+		MinifyStaticHtml: true,
+	}
+
 	payload := ApplicationDelivery{
 		Network:         network,
 		CustomErrorPage: customErrorPage,
+		Compression:     compression,
 	}
 
 	_, err := client.UpdateApplicationDelivery(siteID, &payload)

--- a/website/docs/r/application_delivery.html.markdown
+++ b/website/docs/r/application_delivery.html.markdown
@@ -46,7 +46,7 @@ resource "incapsula_application_delivery" "example_application_delivery" {
 The following arguments are supported:
 
 * `site_id` - (Required) Numeric identifier of the site to operate on.
-* `file_compression` - (Optional) Compress JPEG images. Compression reduces download time by reducing the file size. Default: true
+* `file_compression` - (Optional) When this option is enabled, files such as JavaScript, CSS and HTML are dynamically compressed using the selected format as they are transferred. They are automatically unzipped within the browser. If Brotli is not supported by the browser, files are automatically sent in Gzip. Default: true
 * `compression_type` - (Optional) BROTLI (recommended for more efficient compression). Default: GZIP
 * `minify_js` - (Optional) Minify JavaScript. Minification removes characters that are not necessary for rendering the page, such as whitespace and comments. This makes the files smaller and therefore reduces their access time. Minification has no impact on the functionality of the Javascript, CSS, and HTML files. Default: true
 * `minify_css` - (Optional) Content minification can applied only to cached Javascript, CSS and HTML content. Default: true.


### PR DESCRIPTION
Fix/ on the delete delivery API - while returning to the default setting we had to update the Compression object manually, otherwise, Go would have to fill in the default values it knows such as:   
- empty string value in compression_type instead of "GZIP".

Fixed the test by passing "GZIP" as the value of compression_type