### PR TITLE
#MY-15714 fix rewrite_existing cannot be set to false

### DIFF
--- a/examples/example.tf
+++ b/examples/example.tf
@@ -734,14 +734,13 @@ resource "incapsula_api_security_api_configuration" "example-api-security-api-co
     site_id = 123
     api_specification = "${file("/path/to/swagger/file.yaml")}"
     validate_host = true
-    description = "put your description here"
     invalid_url_violation_action = "BLOCK_REQUEST"
     invalid_method_violation_action = "BLOCK_IP"
     missing_param_violation_action = "IGNORE"
     invalid_param_value_violation_action = "IGNORE"
-	description = "your site API description"
-	base_path = "/base/path"
-	host_name = "host.name.com"
+    description = "your site API description"
+    base_path = "/base/path"
+    host_name = "host.name.com"
 }
 
 ###################################################################

--- a/incapsula/client_incap_rule.go
+++ b/incapsula/client_incap_rule.go
@@ -15,7 +15,7 @@ type IncapRule struct {
 	Filter                string `json:"filter,omitempty"`
 	ResponseCode          int    `json:"response_code,omitempty"`
 	AddMissing            bool   `json:"add_missing,omitempty"`
-	rewriteExisting       bool   `json:"rewrite_existing,omitempty"`
+	RewriteExisting       *bool  `json:"rewrite_existing,omitempty"`
 	From                  string `json:"from,omitempty"`
 	To                    string `json:"to,omitempty"`
 	RewriteName           string `json:"rewrite_name,omitempty"`
@@ -47,6 +47,8 @@ func (c *Client) AddIncapRule(siteID string, rule *IncapRule) (*IncapRuleWithID,
 	if err != nil {
 		return nil, fmt.Errorf("Failed to JSON marshal IncapRule: %s", err)
 	}
+
+	log.Printf("[DEBUG] Create rule DTO request: %v\n", string(ruleJSON[:]))
 
 	// Post form to Incapsula
 	reqURL := fmt.Sprintf("%s/sites/%s/rules", c.config.BaseURLRev2, siteID)
@@ -118,6 +120,8 @@ func (c *Client) UpdateIncapRule(siteID string, ruleID int, rule *IncapRule) (*I
 	if err != nil {
 		return nil, fmt.Errorf("Failed to JSON marshal IncapRule: %s", err)
 	}
+
+	log.Printf("[DEBUG] Update rule DTO request: %v\n", string(ruleJSON[:]))
 
 	// Put request to Incapsula
 	reqURL := fmt.Sprintf("%s/sites/%s/rules/%d", c.config.BaseURLRev2, siteID, ruleID)

--- a/incapsula/resource_incap_rule.go
+++ b/incapsula/resource_incap_rule.go
@@ -69,6 +69,7 @@ func resourceIncapRule() *schema.Resource {
 				Description: "Rewrite cookie or header if it exists.",
 				Type:        schema.TypeBool,
 				Optional:    true,
+				Default:     true,
 			},
 			"from": {
 				Description: "Pattern to rewrite. For `RULE_ACTION_REWRITE_URL` - Url to rewrite. For `RULE_ACTION_REWRITE_HEADER` and `RULE_ACTION_RESPONSE_REWRITE_HEADER` - Header value to rewrite. For `RULE_ACTION_REWRITE_COOKIE` - Cookie value to rewrite.",
@@ -153,14 +154,23 @@ func resourceIncapRule() *schema.Resource {
 
 func resourceIncapRuleCreate(d *schema.ResourceData, m interface{}) error {
 	client := m.(*Client)
+	rewriteExisting := new(bool)
+	action := d.Get("action").(string)
+
+	//#MY-15714 rewrite_existing mustn't be set for other rule types
+	if action == "RULE_ACTION_RESPONSE_REWRITE_HEADER" || action == "RULE_ACTION_REWRITE_HEADER" || action == "RULE_ACTION_REWRITE_COOKIE" {
+		*rewriteExisting = d.Get("rewrite_existing").(bool)
+	} else {
+		rewriteExisting = nil
+	}
 
 	rule := IncapRule{
 		Name:                  d.Get("name").(string),
-		Action:                d.Get("action").(string),
+		Action:                action,
 		Filter:                d.Get("filter").(string),
 		ResponseCode:          d.Get("response_code").(int),
 		AddMissing:            d.Get("add_missing").(bool),
-		rewriteExisting:       d.Get("rewrite_existing").(bool),
+		RewriteExisting:       rewriteExisting,
 		From:                  d.Get("from").(string),
 		To:                    d.Get("to").(string),
 		RewriteName:           d.Get("rewrite_name").(string),
@@ -216,7 +226,6 @@ func resourceIncapRuleRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("filter", rule.Filter)
 	d.Set("response_code", rule.ResponseCode)
 	d.Set("add_missing", rule.AddMissing)
-	d.Set("rewrite_existing", rule.rewriteExisting)
 	d.Set("from", rule.From)
 	d.Set("to", rule.To)
 	d.Set("rewrite_name", rule.RewriteName)
@@ -233,19 +242,36 @@ func resourceIncapRuleRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("override_waf_action", rule.OverrideWafAction)
 	d.Set("enabled", rule.Enabled)
 
+	action := d.Get("action").(string)
+
+	if action == "RULE_ACTION_RESPONSE_REWRITE_HEADER" || action == "RULE_ACTION_REWRITE_HEADER" || action == "RULE_ACTION_REWRITE_COOKIE" {
+		if rule.RewriteExisting != nil {
+			d.Set("rewrite_existing", *rule.RewriteExisting)
+		}
+	}
+
 	return nil
 }
 
 func resourceIncapRuleUpdate(d *schema.ResourceData, m interface{}) error {
 	client := m.(*Client)
+	rewriteExisting := new(bool)
+	action := d.Get("action").(string)
+
+	//#MY-15714 rewrite_existing mustn't be set for other rule types
+	if action == "RULE_ACTION_RESPONSE_REWRITE_HEADER" || action == "RULE_ACTION_REWRITE_HEADER" || action == "RULE_ACTION_REWRITE_COOKIE" {
+		*rewriteExisting = d.Get("rewrite_existing").(bool)
+	} else {
+		rewriteExisting = nil
+	}
 
 	rule := IncapRule{
 		Name:                  d.Get("name").(string),
-		Action:                d.Get("action").(string),
+		Action:                action,
 		Filter:                d.Get("filter").(string),
 		ResponseCode:          d.Get("response_code").(int),
 		AddMissing:            d.Get("add_missing").(bool),
-		rewriteExisting:       d.Get("rewrite_existing").(bool),
+		RewriteExisting:       rewriteExisting,
 		From:                  d.Get("from").(string),
 		To:                    d.Get("to").(string),
 		RewriteName:           d.Get("rewrite_name").(string),


### PR DESCRIPTION
when setting rewrite_existing field to false - while for TF it's equivalent to null, and thus not sent, from the server POV `null=true` so the state is never aligned.