### PR TITLE
Issue 344 

### DIFF
--- a/incapsula/resource_policy_asset_association.go
+++ b/incapsula/resource_policy_asset_association.go
@@ -93,7 +93,8 @@ func resourcePolicyAssetAssociationRead(d *schema.ResourceData, m interface{}) e
 
 	if !isAssociated {
 		log.Printf("[ERROR] Could not find Incapsula Policy Asset Association: %s-%s-%s\n", policyID, assetID, assetType)
-		return fmt.Errorf("Incapsula Policy Asset Association doesn't exisits: policy id:%s asset id:%s asset type:%s\n", policyID, assetID, assetType)
+		d.SetId("")
+		return nil
 	}
 
 	log.Printf("[INFO] Successfully read Policy Asset Association exist: %s-%s-%s\n", policyID, assetID, assetType)


### PR DESCRIPTION
Error with asset association drift failure. Removed the return error for no association, setting the Id to empty and this allows the plan to complete.