### PR TITLE
doc: Explain the (sub-)account limitations for the ABP resource

### DIFF
--- a/incapsula/resource_abp_websites.go
+++ b/incapsula/resource_abp_websites.go
@@ -74,7 +74,9 @@ func resourceAbpWebsites() *schema.Resource {
 			},
 		},
 
-		Description: "Provides an Incapsula ABP (Advanced Bot Protection) website resource. Allows you to enable and configure ABP for given websites.",
+		Description: "Provides an Incapsula ABP (Advanced Bot Protection) website resource. Allows you to enable and configure ABP for given websites.\n" +
+			"\n" +
+			"NOTE: Due to limitations in ABP, the API key/id used to deploy this resource must match the `account_id` used in the resource (API key/id for a parent account do not work). All Incapsula sites associated with the resource must also be defined in that account.",
 
 		Schema: map[string]*schema.Schema{
 			"account_id": {

--- a/website/docs/r/abp_websites.markdown
+++ b/website/docs/r/abp_websites.markdown
@@ -4,11 +4,14 @@ page_title: "incapsula_abp_websites Resource - terraform-provider-incapsula"
 subcategory: ""
 description: |-
   Provides an Incapsula ABP (Advanced Bot Protection) website resource. Allows you to enable and configure ABP for given websites.
+  NOTE: Due to limitations in ABP, the API key/id used to deploy this resource must match the account_id used in the resource (API key/id for a parent account do not work). All Incapsula sites associated with the resource must also be defined in that account.
 ---
 
 # incapsula_abp_websites (Resource)
 
 Provides an Incapsula ABP (Advanced Bot Protection) website resource. Allows you to enable and configure ABP for given websites.
+
+NOTE: Due to limitations in ABP, the API key/id used to deploy this resource must match the `account_id` used in the resource (API key/id for a parent account do not work). All Incapsula sites associated with the resource must also be defined in that account.
 
 ## Example Usage
 


### PR DESCRIPTION
ABP does not fully understand sub-account/parent account relationships which limits what the terraform resource can do. This adds an explainer to reduce confusion when the resource is being setup.