### PR TITLE
Extend ssl settings with tls configurations

### DIFF
--- a/incapsula/client_site_ssl_settings.go
+++ b/incapsula/client_site_ssl_settings.go
@@ -15,27 +15,38 @@ type HSTSConfiguration struct {
 	PreLoaded          bool `json:"preLoaded"`
 }
 
-type Data struct {
-	HstsConfiguration HSTSConfiguration `json:"hstsConfiguration"`
+type InboundTLSSettingsConfiguration struct {
+	ConfigurationProfile string             `json:"configurationProfile"`
+	TLSConfigurations    []TLSConfiguration `json:"tlsConfiguration"`
+}
+
+type TLSConfiguration struct {
+	TLSVersion     string   `json:"tlsVersion"`
+	CiphersSupport []string `json:"ciphersSupport"`
 }
 
 type SSLSettingsDTO struct {
-	Data []Data `json:"data"`
+	HstsConfiguration               HSTSConfiguration                `json:"hstsConfiguration"`
+	InboundTLSSettingsConfiguration *InboundTLSSettingsConfiguration `json:"inboundTlsSettings,omitempty"`
 }
 
-func (c *Client) UpdateSiteSSLSettings(siteID int, mySSLSettings SSLSettingsDTO) (*SSLSettingsDTO, error) {
+type SSLSettingsResponse struct {
+	Data []SSLSettingsDTO `json:"data"`
+}
+
+func (c *Client) UpdateSiteSSLSettings(siteID int, mySSLSettings SSLSettingsResponse) (*SSLSettingsResponse, error) {
 	log.Printf("[INFO] Updating Incapsula Site SSL settings for Site ID %d\n", siteID)
 
 	requestJSON, err := json.Marshal(mySSLSettings)
 	if err != nil {
-		return nil, fmt.Errorf("failed to JSON marshal HSTSConfiguration: %s", err)
+		return nil, fmt.Errorf("failed to JSON marshal SSLSettings: %s", err)
 	}
 
-	// Put request to Incapsula
-	reqURL := fmt.Sprintf("%s/sites/%d/settings/TLSConfiguration", c.config.BaseURLRev3, siteID)
-	log.Printf("[INFO] HSTS request json looks like this %s\n", requestJSON)
-	log.Printf("[INFO] HSTS request URL looks like this %s\n", reqURL)
-	resp, err := c.DoJsonRequestWithHeaders(http.MethodPost, reqURL, requestJSON, UpdateSiteSSLSettings)
+	// Patch request to Incapsula
+	reqURL := fmt.Sprintf("%s/sites-mgmt/v3/sites/%d/settings/TLSConfiguration", c.config.BaseURLAPI, siteID)
+	log.Printf("[INFO] SSL Settings request json looks like this %s\n", requestJSON)
+	log.Printf("[INFO] SSL Settings request URL looks like this %s\n", reqURL)
+	resp, err := c.DoJsonRequestWithHeaders(http.MethodPatch, reqURL, requestJSON, UpdateSiteSSLSettings)
 	if err != nil {
 		return nil, fmt.Errorf("error from Incapsula service when updating Site SSL settings %s for Site ID %d: %s", requestJSON, siteID, err)
 	}
@@ -53,20 +64,20 @@ func (c *Client) UpdateSiteSSLSettings(siteID int, mySSLSettings SSLSettingsDTO)
 	}
 
 	// Parse the JSON
-	var sslSettingsDTO SSLSettingsDTO
-	err = json.Unmarshal([]byte(responseBody), &sslSettingsDTO)
+	var sslSettingsResponse SSLSettingsResponse
+	err = json.Unmarshal([]byte(responseBody), &sslSettingsResponse)
 	if err != nil {
 		return nil, fmt.Errorf("Error parsing Incap Site settings JSON response for Site ID %d: %s\nresponse: %s", siteID, err, string(responseBody))
 	}
 
-	return &sslSettingsDTO, nil
+	return &sslSettingsResponse, nil
 }
 
-func (c *Client) ReadSiteSSLSettings(siteID int) (*SSLSettingsDTO, int, error) {
+func (c *Client) ReadSiteSSLSettings(siteID int) (*SSLSettingsResponse, int, error) {
 	log.Printf("[INFO] Getting Incapsula Incap SSL settings for Site ID %d\n", siteID)
 
-	// Post form to Incapsula
-	reqURL := fmt.Sprintf("%s/sites/%d/settings/TLSConfiguration", c.config.BaseURLRev3, siteID)
+	// Get form to Incapsula
+	reqURL := fmt.Sprintf("%s/sites-mgmt/v3/sites/%d/settings/TLSConfiguration", c.config.BaseURLAPI, siteID)
 	resp, err := c.DoJsonRequestWithHeaders(http.MethodGet, reqURL, nil, ReadSiteSSLSettings)
 	if err != nil {
 		return nil, 0, fmt.Errorf("error from Incapsula service when reading SSL Settings for Site ID %d: %s", siteID, err)
@@ -85,11 +96,11 @@ func (c *Client) ReadSiteSSLSettings(siteID int) (*SSLSettingsDTO, int, error) {
 	}
 
 	// Parse the JSON
-	var sslSettingsDTO SSLSettingsDTO
-	err = json.Unmarshal([]byte(responseBody), &sslSettingsDTO)
+	var sslSettingsResponse SSLSettingsResponse
+	err = json.Unmarshal([]byte(responseBody), &sslSettingsResponse)
 	if err != nil {
 		return nil, resp.StatusCode, fmt.Errorf("error parsing Site SSL settings JSON response for Site ID %d: %s\nresponse: %s", siteID, err, string(responseBody))
 	}
 
-	return &sslSettingsDTO, resp.StatusCode, nil
+	return &sslSettingsResponse, resp.StatusCode, nil
 }

--- a/incapsula/client_site_ssl_settings_test.go
+++ b/incapsula/client_site_ssl_settings_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestUpdateSiteSSLSettingsHandleBadConnection(t *testing.T) {
 	// arrange
-	config := &Config{APIID: "foo", APIKey: "bar", BaseURLRev3: "badness.incapsula.com"}
+	config := &Config{APIID: "foo", APIKey: "bar", BaseURLRev3: "badness.incapsula.com", BaseURLAPI: "badness.incapsula.com"}
 	client := &Client{config: config, httpClient: &http.Client{Timeout: time.Millisecond * 1}}
 	sslSettingsDTO := getUpdateSiteSSLSettingsDTO()
 
@@ -34,7 +34,7 @@ func TestUpdateSiteSSLSettingsHandleResponseCodeNotSuccess(t *testing.T) {
 	apiKey := "bar"
 	siteID := 42
 
-	endpoint := fmt.Sprintf("/sites/%d/settings/TLSConfiguration", siteID)
+	endpoint := fmt.Sprintf("/sites-mgmt/v3/sites/%d/settings/TLSConfiguration", siteID)
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(406)
@@ -71,7 +71,7 @@ func TestUpdateSiteSSLSettingsHandleInvalidResponseBody(t *testing.T) {
 	apiKey := "bar"
 	siteID := 42
 
-	endpoint := fmt.Sprintf("/sites/%d/settings/TLSConfiguration", siteID)
+	endpoint := fmt.Sprintf("/sites-mgmt/v3/sites/%d/settings/TLSConfiguration", siteID)
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(200)
 
@@ -110,7 +110,7 @@ func TestUpdateSiteSSLSettingsSuccess(t *testing.T) {
 
 	validResponse := getValidJSONResponse()
 
-	endpoint := fmt.Sprintf("/sites/%d/settings/TLSConfiguration", siteID)
+	endpoint := fmt.Sprintf("/sites-mgmt/v3/sites/%d/settings/TLSConfiguration", siteID)
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(200)
 
@@ -163,7 +163,7 @@ func TestReadSiteSSLSettingsHandleResponseCodeNotSuccess(t *testing.T) {
 	apiKey := "bar"
 	siteID := 42
 
-	endpoint := fmt.Sprintf("/sites/%d/settings/TLSConfiguration", siteID)
+	endpoint := fmt.Sprintf("/sites-mgmt/v3/sites/%d/settings/TLSConfiguration", siteID)
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(406)
@@ -199,7 +199,7 @@ func TestReadSiteSSLSettingsHandleInvalidResponseBody(t *testing.T) {
 	apiKey := "bar"
 	siteID := 42
 
-	endpoint := fmt.Sprintf("/sites/%d/settings/TLSConfiguration", siteID)
+	endpoint := fmt.Sprintf("/sites-mgmt/v3/sites/%d/settings/TLSConfiguration", siteID)
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(200)
 
@@ -237,7 +237,7 @@ func TestReadSiteSSLSettingsSuccess(t *testing.T) {
 
 	var validResponse = getValidJSONResponse()
 
-	endpoint := fmt.Sprintf("/sites/%d/settings/TLSConfiguration", siteID)
+	endpoint := fmt.Sprintf("/sites-mgmt/v3/sites/%d/settings/TLSConfiguration", siteID)
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(200)
 
@@ -265,9 +265,9 @@ func TestReadSiteSSLSettingsSuccess(t *testing.T) {
 	}
 }
 
-func getUpdateSiteSSLSettingsDTO() SSLSettingsDTO {
-	var sslSettingsDTO = SSLSettingsDTO{
-		Data: []Data{
+func getUpdateSiteSSLSettingsDTO() SSLSettingsResponse {
+	var sslSettingsDTO = SSLSettingsResponse{
+		Data: []SSLSettingsDTO{
 			{
 				HstsConfiguration: HSTSConfiguration{
 					PreLoaded:          true,
@@ -275,10 +275,30 @@ func getUpdateSiteSSLSettingsDTO() SSLSettingsDTO {
 					SubDomainsIncluded: true,
 					IsEnabled:          true,
 				},
+				InboundTLSSettingsConfiguration: &InboundTLSSettingsConfiguration{
+					ConfigurationProfile: "CUSTOM",
+					TLSConfigurations: []TLSConfiguration{
+						{
+							TLSVersion: "TLS 1.1",
+							CiphersSupport: []string{
+								"TLS_AES_128_GCM_SHA256",
+								"TLS_AES_128_GCM_SHA256",
+							},
+						},
+						{
+							TLSVersion: "TLS 1.2",
+							CiphersSupport: []string{
+								"TLS_AES_128_GCM_SHA256",
+								"TLS_AES_128_GCM_SHA256",
+							},
+						},
+					},
+				},
 				// add more setting types here
 			},
 		},
 	}
+
 	return sslSettingsDTO
 }
 
@@ -295,7 +315,7 @@ func getClientTestConfig(apiID string, apiKey string, server *httptest.Server) *
 }
 
 func getValidJSONResponse() string {
-	var invalidResponse = `{
+	var validResponse = `{
 			"data":[
 				{
 					"hstsConfiguration":{
@@ -303,9 +323,21 @@ func getValidJSONResponse() string {
 						"maxAge":31536000,
 						"subDomainsIncluded":true,
 						"preLoaded":false
-					}
+					},
+                    "inboundTlsSettings": {
+                        "configurationProfile": "CUSTOM",
+                        "tlsConfiguration": [
+                            {
+                                "tlsVersion": "TLS 1.1",
+                                "ciphersSupport": [
+                                    "TLS_AES_128_GCM_SHA256",
+                                    "TLS_AES_128_GCM_SHA256"
+                                ]
+                            }
+                        ]
+                    }
 				}
 			]
 		}`
-	return invalidResponse
+	return validResponse
 }

--- a/website/docs/r/site_ssl_settings.html.markdown
+++ b/website/docs/r/site_ssl_settings.html.markdown
@@ -8,12 +8,16 @@ description: |- Provides an Incapsula Site SSL Settings resource.
 
 Provides an Incapsula Site SSL Settings resource.
 
-If you run the same resource from a site for which SSL is not yet enabled and **approved** will result in the following error response:
+In this resource you can configure:
+- HSTS: A security mechanism enabling websites to announce themselves as accessible only via HTTPS. 
+For more information about HSTS, click [here](https://www.imperva.com/blog/hsts-strict-transport-security/).
+- TLS settings: Define the supported TLS version and cipher suites used for encryption of the TLS handshake between client and Imperva. 
+For more information about supported TLS versions and ciphers, click [here](https://docs.imperva.com/bundle/cloud-application-security/page/cipher-suites.htm).
+
+If you run the SSL settings resource from a site for which SSL is not yet enabled and the SSL certificate is not approved, it will result in the following error response:
 - `status:` 406 
 - `message:` Site does not have SSL configured
 - To enable this feature for your site, you must first configure its SSL settings including a valid certificate.
-
-For more information what HSTS is click [here](https://www.imperva.com/blog/hsts-strict-transport-security/).
 
 ## Example Usage
 
@@ -27,6 +31,18 @@ resource "incapsula_site_ssl_settings" "example"  {
     sub_domains_included = true
     pre_loaded = false
   }
+  inbound_tls_settings { 
+    configuration_profile     = "CUSTOM"
+
+    tls_configuration { 
+      tls_version             = "TLS_1_2"
+      ciphers_support         = ["TLS_CHACHA20_POLY1305_SHA256", "TLS_AES_256_GCM_SHA384"]
+    }
+    tls_configuration { 
+      tls_version             = "TLS_1_3"
+      ciphers_support         = ["TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"]
+    }
+  }
 }
 ```
 
@@ -37,6 +53,8 @@ The following arguments are supported:
 * `site_id` - (Required) Numeric identifier of the site to operate on.
 * `hsts` - (Optional): HTTP Strict Transport Security (HSTS) configuration settings for the site.
     - Type: `set` of `hsts_config` resource (defined below)
+* `inbound_tls_settings` - (Optional): Transport Layer Security (TLS) configuration settings for the site.
+  - Type: `set` of `inbound_tls_settings` resource (defined below)
 
 ## Schema of `hsts_config` resource
 
@@ -54,6 +72,23 @@ The `hsts_config` resource represents the configuration settings for HTTP Strict
 * `pre_loaded` - (Optional): Whether the site is preloaded in the HSTS preload list maintained by browsers.
     - Type: `bool`
     - Default: `false`
+
+## Schema of `inbound_tls_settings` resource
+
+The `inbound_tls_settings` resource represents the configuration settings for Transport Layer Security (TLS).
+
+* `configuration_profile` - (Required): Where to use a pre-defined or custom configuration for TLS settings.
+  - Type: `string`
+* `tls_configuration` - (Optional): List supported TLS versions and ciphers.
+  - Type: `List`
+
+### Nested Schema for `tls_configuration`
+
+* `tls_version` - (Required): TLS supported versions.
+  - Type: `string`
+* `ciphers_support` - (Required): List of ciphers to use for this TLS version.
+  - Type: `List`
+
 
 ## Attributes Reference
 


### PR DESCRIPTION
Extending the site ssl settings resource and adding inbound TLS settings that will allow clients to configure which tls versions and which ciphers to use at the site level.
And extending the already existing ssl settings resource tests to cover inbound TLS settings.