### PR TITLE
the response from "site status" is not consistent -  Res can sometime…

### DIFF
--- a/incapsula/client_security_rule_exception.go
+++ b/incapsula/client_security_rule_exception.go
@@ -167,8 +167,18 @@ func (c *Client) EditSecurityRuleException(siteID int, ruleID, clientAppTypes, c
 		return nil, fmt.Errorf("Error parsing configure security rule exception JSON response for rule_id (%s) and site_id (%d)", ruleID, siteID)
 	}
 
+	// Res can sometimes oscillate between a string and number
+	// We need to add safeguards for this inside the provider
+	var resString string
+
+	if resNumber, ok := siteStatusResponse.Res.(float64); ok {
+		resString = fmt.Sprintf("%d", int(resNumber))
+	} else {
+		resString = siteStatusResponse.Res.(string)
+	}
+
 	// Look at the response status code from Incapsula
-	if siteStatusResponse.Res != 0 {
+	if resString != "0" {
 		return nil, fmt.Errorf("Error from Incapsula service when adding security rule exception for rule_id (%s) and site_id (%d): %s", ruleID, siteID, string(responseBody))
 	}
 


### PR DESCRIPTION
…s oscillate between a string and number, We need safeguards for this inside the provider