### PR TITLE
Change error pages to full-update endpoint

### DIFF
--- a/incapsula/client_application_delivery.go
+++ b/incapsula/client_application_delivery.go
@@ -7,6 +7,8 @@ import (
 	"log"
 	"net/http"
 	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 )
 
 type Compression struct {
@@ -16,13 +18,6 @@ type Compression struct {
 	MinifyCss        bool   `json:"minify_css"`
 	MinifyStaticHtml bool   `json:"minify_static_html"`
 }
-type CompressionStr struct {
-	FileCompression  string `json:"file_compression"`
-	CompressionType  string `json:"compression_type"`
-	MinifyJs         string `json:"minify_js"`
-	MinifyCss        string `json:"minify_css"`
-	MinifyStaticHtml string `json:"minify_static_html"`
-}
 
 type ImageCompression struct {
 	CompressJpeg              bool `json:"compress_jpeg"`
@@ -31,29 +26,12 @@ type ImageCompression struct {
 	CompressPng               bool `json:"compress_png"`
 }
 
-type ImageCompressionStr struct {
-	CompressJpeg              string
-	ProgressiveImageRendering string
-	AggressiveCompression     string
-	CompressPng               string
-}
-
 type Network struct {
 	TcpPrePooling         bool    `json:"tcp_pre_pooling"`
 	OriginConnectionReuse bool    `json:"origin_connection_reuse"`
 	SupportNonSniClients  bool    `json:"support_non_sni_clients"`
 	EnableHttp2           *bool   `json:"enable_http2"`
 	Http2ToOrigin         *bool   `json:"http2_to_origin"`
-	Port                  Port    `json:"port"`
-	SslPort               SslPort `json:"ssl_port"`
-}
-
-type NetworkStr struct {
-	TcpPrePooling         string  `json:"tcp_pre_pooling"`
-	OriginConnectionReuse string  `json:"origin_connection_reuse"`
-	SupportNonSniClients  string  `json:"support_non_sni_clients"`
-	EnableHttp2           string  `json:"enable_http2"`
-	Http2ToOrigin         string  `json:"http2_to_origin"`
 	Port                  Port    `json:"port"`
 	SslPort               SslPort `json:"ssl_port"`
 }
@@ -71,25 +49,20 @@ type Redirection struct {
 	RedirectHttpToHttps bool `json:"redirect_http_to_https"`
 }
 
-type RedirectionStr struct {
-	RedirectNakedToFullStr string `json:"redirect_naked_to_full"`
-	RedirectHttpToHttpsStr string `json:"redirect_http_to_https"`
-}
-
 type CustomErrorPageTemplates struct {
-	ErrorConnectionTimeout       string `json:"error.type.connection_timeout"`
-	ErrorAccessDenied            string `json:"error.type.access_denied"`
-	ErrorParseReqError           string `json:"error.type.parse_req_error"`
-	ErrorParseRespError          string `json:"error.type.parse_resp_error"`
-	ErrorConnectionFailed        string `json:"error.type.connection_failed"`
-	ErrorSslFailed               string `json:"error.type.ssl_failed"`
-	ErrorDenyAndCaptcha          string `json:"error.type.deny_and_captcha"`
-	ErrorTypeNoSslConfig         string `json:"error.type.no_ssl_config"`
-	ErrorAbpIdentificationFailed string `json:"error.type.abp_identification_failed"`
+	ErrorConnectionTimeout       string `json:"error.type.connection_timeout,omitempty"`
+	ErrorAccessDenied            string `json:"error.type.access_denied,omitempty"`
+	ErrorParseReqError           string `json:"error.type.parse_req_error,omitempty"`
+	ErrorParseRespError          string `json:"error.type.parse_resp_error,omitempty"`
+	ErrorConnectionFailed        string `json:"error.type.connection_failed,omitempty"`
+	ErrorSslFailed               string `json:"error.type.ssl_failed,omitempty"`
+	ErrorDenyAndCaptcha          string `json:"error.type.deny_and_captcha,omitempty"`
+	ErrorTypeNoSslConfig         string `json:"error.type.no_ssl_config,omitempty"`
+	ErrorAbpIdentificationFailed string `json:"error.type.abp_identification_failed,omitempty"`
 }
 
 type CustomErrorPage struct {
-	DefaultErrorPage         string                   `json:"error_page_template"`
+	DefaultErrorPage         string                   `json:"error_page_template,omitempty"`
 	CustomErrorPageTemplates CustomErrorPageTemplates `json:"custom_error_page_templates"`
 }
 
@@ -98,33 +71,50 @@ type ApplicationDelivery struct {
 	ImageCompression ImageCompression `json:"image_compression"`
 	Network          Network          `json:"network"`
 	Redirection      Redirection      `json:"redirection"`
-	CustomErrorPage  CustomErrorPage  `json:"custom_error_page"`
 }
 
-func (c *Client) GetApplicationDelivery(siteID int) (*ApplicationDelivery, error) {
+func (c *Client) GetApplicationDelivery(siteID int) (*ApplicationDelivery, diag.Diagnostics) {
 	log.Printf("[INFO] Getting Incapsula Application Delivery for Site ID %d", siteID)
 	return CrudApplicationDelivery("Read", siteID, http.MethodGet, nil, c)
 }
 
-func (c *Client) UpdateApplicationDelivery(siteID int, applicationDelivery *ApplicationDelivery) (*ApplicationDelivery, error) {
+func (c *Client) UpdateApplicationDelivery(siteID int, applicationDelivery *ApplicationDelivery) (*ApplicationDelivery, diag.Diagnostics) {
 	log.Printf("[INFO] Updating Incapsula Application Delivery for Site ID %d", siteID)
+	var diags diag.Diagnostics
 	applicationDeliveryJSON, err := json.Marshal(applicationDelivery)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to JSON marshal Application Delivery for SiteID: %s", err)
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Failed JSON marshalling Application Delivery resource",
+			Detail:   fmt.Sprintf("Failed to JSON marshal Application Delivery for SiteID %d: %s", siteID, err),
+		})
+		return nil, diags
 	}
 	return CrudApplicationDelivery("Update", siteID, http.MethodPut, applicationDeliveryJSON, c)
 }
 
-func (c *Client) DeleteApplicationDelivery(siteID int) (*ApplicationDelivery, error) {
+func (c *Client) DeleteApplicationDelivery(siteID int) (*ApplicationDelivery, diag.Diagnostics) {
 	log.Printf("[INFO] Deleting Incapsula Application Delivery for Site ID %d", siteID)
 	return CrudApplicationDelivery("Delete", siteID, http.MethodDelete, nil, c)
 }
 
-func CrudApplicationDelivery(action string, siteID int, hhtpMethod string, data []byte, c *Client) (*ApplicationDelivery, error) {
-	url := fmt.Sprintf("%s/sites/%d/settings/delivery", c.config.BaseURLRev2, siteID)
-	resp, err := c.DoJsonRequestWithHeaders(hhtpMethod, url, data, strings.ToLower(action)+"_application_delivery")
+func CrudApplicationDelivery(action string, siteID int, httpMethod string, applicationDeliveyData []byte, c *Client) (*ApplicationDelivery, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if applicationDeliveyData != nil {
+		log.Printf("[DEBUG] Incapsula %s Application Delivery JSON request: %s\n", action, string(applicationDeliveyData))
+	}
+
+	applicationDeliveryUrl := fmt.Sprintf("%s/sites/%d/settings/delivery", c.config.BaseURLRev2, siteID)
+
+	resp, err := c.DoJsonRequestWithHeaders(httpMethod, applicationDeliveryUrl, applicationDeliveyData, strings.ToLower(action)+"_application_delivery")
 	if err != nil {
-		return nil, fmt.Errorf("[ERROR] Error from Incapsula service when trying to %s Application Delivery for Site ID %d: %s", strings.ToLower(action), siteID, err)
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  fmt.Sprintf("Error from Incapsula service when trying to %s Application Delivery", strings.ToLower(action)),
+			Detail:   fmt.Sprintf("Error from Incapsula service when trying to %s Application Delivery for Site ID %d: %s", strings.ToLower(action), siteID, err),
+		})
+		return nil, diags
 	}
 
 	// Read the body
@@ -134,15 +124,101 @@ func CrudApplicationDelivery(action string, siteID int, hhtpMethod string, data 
 
 	// Check the response code
 	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("Error status code %d from Incapsula service when %s Application Delivery for Site ID %d: %s", resp.StatusCode, strings.TrimSuffix(action, "e")+"ing", siteID, string(responseBody))
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  fmt.Sprintf("Error status code %d from Incapsula service when %s Application Delivery", resp.StatusCode, strings.TrimSuffix(action, "e")+"ing"),
+			Detail:   fmt.Sprintf("Error status code %d from Incapsula service when %s Application Delivery for Site ID %d: %s", resp.StatusCode, strings.TrimSuffix(action, "e")+"ing", siteID, string(responseBody)),
+		})
+		return nil, diags
 	}
 
 	// Dump JSON
 	var applicationDelivery ApplicationDelivery
 	err = json.Unmarshal([]byte(responseBody), &applicationDelivery)
 	if err != nil {
-		return nil, fmt.Errorf("[ERROR] Error parsing Application Delivery Response JSON response for Site ID %d: %s\nresponse: %s", siteID, err, string(responseBody))
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  fmt.Sprintf("Error parsing Application Delivery Response JSON response"),
+			Detail:   fmt.Sprintf("Error parsing Application Delivery Response JSON response for Site ID %d: %s\nresponse: %s", siteID, err, string(responseBody)),
+		})
+		return nil, diags
 	}
 
 	return &applicationDelivery, nil
+}
+
+func (c *Client) GetErrorPages(siteID int) (*CustomErrorPage, diag.Diagnostics) {
+	log.Printf("[INFO] Getting Incapsula Error Pages for Site ID %d", siteID)
+	return CrudErrorPages("Read", siteID, http.MethodGet, nil, c)
+}
+
+func (c *Client) UpdateErrorPages(siteID int, errorPages *CustomErrorPage) (*CustomErrorPage, diag.Diagnostics) {
+	log.Printf("[INFO] Updating Incapsula Application Delivery for Site ID %d", siteID)
+	var diags diag.Diagnostics
+	errorPagesJSON, err := json.Marshal(errorPages)
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Failed JSON marshalling Error Pages resource",
+			Detail:   fmt.Sprintf("Failed to JSON marshal Error Pages for SiteID %d: %s", siteID, err),
+		})
+		return nil, diags
+	}
+	return CrudErrorPages("Update", siteID, http.MethodPut, errorPagesJSON, c)
+}
+
+func (c *Client) DeleteErrorPages(siteID int) (*CustomErrorPage, diag.Diagnostics) {
+	log.Printf("[INFO] Deleting Incapsula Application Delivery for Site ID %d", siteID)
+	customErrorPage := CustomErrorPage{}
+	errorPagesJSON, _ := json.Marshal(customErrorPage)
+	return CrudErrorPages("Delete", siteID, http.MethodPut, errorPagesJSON, c)
+}
+
+func CrudErrorPages(action string, siteID int, httpMethod string, errorPagesData []byte, c *Client) (*CustomErrorPage, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if errorPagesData != nil {
+		log.Printf("[DEBUG] Incapsula %s Error Pages JSON request: %s\n", action, string(errorPagesData))
+	}
+
+	errorPagesUrl := fmt.Sprintf("%s/sites/%d/settings/delivery/error-pages", c.config.BaseURLRev2, siteID)
+
+	resp, err := c.DoJsonRequestWithHeaders(httpMethod, errorPagesUrl, errorPagesData, strings.ToLower(action)+"_error_pages")
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  fmt.Sprintf("Error from Incapsula service when trying to %s Error Pages", strings.ToLower(action)),
+			Detail:   fmt.Sprintf("Error from Incapsula service when trying to %s Error Pages for Site ID %d: %s", strings.ToLower(action), siteID, err),
+		})
+		return nil, diags
+	}
+
+	// Read the body
+	defer resp.Body.Close()
+	responseBody, _ := ioutil.ReadAll(resp.Body)
+	log.Printf("[DEBUG] Incapsula %s Error pages JSON response: %s\n", action, string(responseBody))
+
+	// Check the response code
+	if resp.StatusCode != 200 {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  fmt.Sprintf("Error status code %d from Incapsula service when %s Error Pages", resp.StatusCode, strings.TrimSuffix(action, "e")+"ing"),
+			Detail:   fmt.Sprintf("Error status code %d from Incapsula service when %s Error Pages for Site ID %d: %s", resp.StatusCode, strings.TrimSuffix(action, "e")+"ing", siteID, string(responseBody)),
+		})
+		return nil, diags
+	}
+
+	// Dump JSON
+	var customErrorPage CustomErrorPage
+	err = json.Unmarshal([]byte(responseBody), &customErrorPage)
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  fmt.Sprintf("Error parsing Error Pages Response JSON response for Site ID %d", siteID),
+			Detail:   fmt.Sprintf("Error parsing Error Pages Response JSON response for Site ID %d: %s\nresponse: %s", siteID, err, string(responseBody)),
+		})
+		return nil, diags
+	}
+
+	return &customErrorPage, nil
 }

--- a/incapsula/client_application_delivery.go
+++ b/incapsula/client_application_delivery.go
@@ -120,7 +120,7 @@ func CrudApplicationDelivery(action string, siteID int, httpMethod string, appli
 	// Read the body
 	defer resp.Body.Close()
 	responseBody, err := ioutil.ReadAll(resp.Body)
-	log.Printf("[DEBUG] Incapsula %s Application Delivery JSON response: %s\n", action, string(responseBody))
+	log.Printf("[DEBUG] Incapsula %s Application Delivery JSON response: (%d) %s\n", action, resp.StatusCode, string(responseBody))
 
 	// Check the response code
 	if resp.StatusCode != 200 {
@@ -196,7 +196,7 @@ func CrudErrorPages(action string, siteID int, httpMethod string, errorPagesData
 	// Read the body
 	defer resp.Body.Close()
 	responseBody, _ := ioutil.ReadAll(resp.Body)
-	log.Printf("[DEBUG] Incapsula %s Error pages JSON response: %s\n", action, string(responseBody))
+	log.Printf("[DEBUG] Incapsula %s Error pages JSON response: (%d) %s\n", action, resp.StatusCode, string(responseBody))
 
 	// Check the response code
 	if resp.StatusCode != 200 {

--- a/incapsula/client_application_delivery_test.go
+++ b/incapsula/client_application_delivery_test.go
@@ -17,26 +17,35 @@ func TestUpdateApplicationDeliveryBadConnection(t *testing.T) {
 	client := &Client{config: config, httpClient: &http.Client{Timeout: time.Millisecond * 1}}
 	siteID := 42
 
-	payload := ApplicationDelivery{
+	applicationDeliveryPayload := ApplicationDelivery{
 		Compression:      Compression{},
 		ImageCompression: ImageCompression{},
 		Network:          Network{},
 		Redirection:      Redirection{},
-		CustomErrorPage:  CustomErrorPage{},
 	}
 
 	applicationDeliveryResponse, err := client.UpdateApplicationDelivery(
 		siteID,
-		&payload)
+		&applicationDeliveryPayload)
 
 	if err == nil {
 		t.Errorf("Should have received an error")
 	}
-	if !strings.HasPrefix(err.Error(), "[ERROR] Error from Incapsula service when trying to update Application Delivery for Site ID 42") {
-		t.Errorf("Should have received an client error, got: %s", err)
-	}
 	if applicationDeliveryResponse != nil {
 		t.Errorf("Should have received a nil applicationDeliveryResponse instance")
+	}
+
+	customErrorPagesPayload := CustomErrorPage{}
+
+	errorPages, err := client.UpdateErrorPages(
+		siteID,
+		&customErrorPagesPayload)
+
+	if err == nil {
+		t.Errorf("Should have received an error")
+	}
+	if errorPages != nil {
+		t.Errorf("Should have received a nil errorPages instance")
 	}
 }
 
@@ -45,11 +54,12 @@ func TestUpdateApplicationDeliveryBadJSON(t *testing.T) {
 	apiKey := "bar"
 	siteID := 42
 
-	endpoint := fmt.Sprintf("/sites/%d/settings/delivery", siteID)
+	applicationDeliveryEndpoint := fmt.Sprintf("/sites/%d/settings/delivery", siteID)
+	errorPagesEndpoint := fmt.Sprintf("/sites/%d/settings/delivery/error-pages", siteID)
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		if req.URL.String() != endpoint {
-			t.Errorf("Should have have hit %s endpoint. Got: %s", endpoint, req.URL.String())
+		if req.URL.String() != applicationDeliveryEndpoint && req.URL.String() != errorPagesEndpoint {
+			t.Errorf("Should have have hit delivery settings endpoint. Got: %s", req.URL.String())
 		}
 		rw.Write([]byte(`{`))
 	}))
@@ -58,26 +68,35 @@ func TestUpdateApplicationDeliveryBadJSON(t *testing.T) {
 	config := &Config{APIID: apiID, APIKey: apiKey, BaseURL: server.URL, BaseURLRev2: server.URL, BaseURLAPI: server.URL}
 	client := &Client{config: config, httpClient: &http.Client{}}
 
-	payload := ApplicationDelivery{
+	applicationDeliveryPayload := ApplicationDelivery{
 		Compression:      Compression{},
 		ImageCompression: ImageCompression{},
 		Network:          Network{},
 		Redirection:      Redirection{},
-		CustomErrorPage:  CustomErrorPage{},
 	}
 
 	applicationDeliveryResponse, err := client.UpdateApplicationDelivery(
 		siteID,
-		&payload)
+		&applicationDeliveryPayload)
 
 	if err == nil {
 		t.Errorf("Should have received an error")
 	}
-	if !strings.HasPrefix(err.Error(), "[ERROR] Error parsing Application Delivery Response JSON response for Site ID") {
-		t.Errorf("Should have received an client error, got: %s", err)
-	}
 	if applicationDeliveryResponse != nil {
 		t.Errorf("Should have received a nil applicationDeliveryResponse instance")
+	}
+
+	customErrorPagesPayload := CustomErrorPage{}
+
+	errorPages, err := client.UpdateErrorPages(
+		siteID,
+		&customErrorPagesPayload)
+
+	if err == nil {
+		t.Errorf("Should have received an error")
+	}
+	if errorPages != nil {
+		t.Errorf("Should have received a nil errorPages instance")
 	}
 }
 
@@ -86,12 +105,13 @@ func TestUpdateApplicationDeliveryInvalidConfig(t *testing.T) {
 	apiKey := "bar"
 	siteID := 42
 
-	endpoint := fmt.Sprintf("/sites/%d/settings/delivery", siteID)
+	applicationDeliveryEndpoint := fmt.Sprintf("/sites/%d/settings/delivery", siteID)
+	errorPagesEndpoint := fmt.Sprintf("/sites/%d/settings/delivery/error-pages", siteID)
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(500)
-		if req.URL.String() != endpoint {
-			t.Errorf("Should have have hit %s endpoint. Got: %s", endpoint, req.URL.String())
+		if req.URL.String() != applicationDeliveryEndpoint && req.URL.String() != errorPagesEndpoint {
+			t.Errorf("Should have have hit delivery settings endpoint. Got: %s", req.URL.String())
 		}
 		rw.Write([]byte(`{
   "errors": [
@@ -113,18 +133,34 @@ func TestUpdateApplicationDeliveryInvalidConfig(t *testing.T) {
 	//invalid payload
 	payload := ApplicationDelivery{}
 
-	applicationDeliveryResponse, err := client.UpdateApplicationDelivery(
+	applicationDeliveryResponse, diags := client.UpdateApplicationDelivery(
 		siteID,
 		&payload)
 
-	if err == nil {
+	if diags == nil {
 		t.Errorf("Should have received an error")
 	}
-	if !strings.HasPrefix(err.Error(), fmt.Sprintf("Error status code 500 from Incapsula service when Updating Application Delivery for Site ID")) {
-		t.Errorf("Should have received a bad Application Delivery error, got: %s", err)
+	if !strings.HasPrefix(diags[0].Detail, fmt.Sprintf("Error status code %d from Incapsula service when %s Application Delivery for Site ID %d", 500, siteID)) {
+		t.Errorf("Should have received a bad Application Delivery error, got: %s", diags[0].Detail)
 	}
 	if applicationDeliveryResponse != nil {
 		t.Errorf("Should have received a nil applicationDeliveryResponse instance")
+	}
+
+	customErrorPagesPayload := CustomErrorPage{}
+
+	errorPages, diags := client.UpdateErrorPages(
+		siteID,
+		&customErrorPagesPayload)
+
+	if diags == nil {
+		t.Errorf("Should have received an error")
+	}
+	if !strings.HasPrefix(diags[0].Detail, fmt.Sprintf("Error status code %d from Incapsula service when %s Error Pages for Site ID %d", 500, siteID)) {
+		t.Errorf("Should have received a bad Application Delivery error, got: %s", diags[0].Detail)
+	}
+	if errorPages != nil {
+		t.Errorf("Should have received a nil errorPages instance")
 	}
 }
 
@@ -133,74 +169,94 @@ func TestUpdateApplicationDeliveryConfig(t *testing.T) {
 	apiKey := "bar"
 	siteID := 42
 
-	endpoint := fmt.Sprintf("/sites/%d/settings/delivery", siteID)
+	applicationDeliveryEndpoint := fmt.Sprintf("/sites/%d/settings/delivery", siteID)
+	errorPagesEndpoint := fmt.Sprintf("/sites/%d/settings/delivery/error-pages", siteID)
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(200)
-		if req.URL.String() != endpoint {
-			t.Errorf("Should have have hit %s endpoint. Got: %s", endpoint, req.URL.String())
+		if req.URL.String() != applicationDeliveryEndpoint && req.URL.String() != errorPagesEndpoint {
+			t.Errorf("Should have have hit delivery settings endpoint. Got: %s", req.URL.String())
 		}
-		rw.Write([]byte(`
-{
-  "compression": {
-    "file_compression": true,
-    "compression_type": "GZIP",
-    "minify_js": true,
-    "minify_css": false,
-    "minify_static_html": true
-  },
-  "image_compression": {
-    "compress_jpeg": true,
-    "progressive_image_rendering": true,
-    "aggressive_compression": false,
-    "compress_png": true
-  },
-  "network": {
-    "tcp_pre_pooling": true,
-    "origin_connection_reuse": false,
-    "support_non_sni_clients": true,
-    "port": {
-      "to": "8080"
-    },
-    "ssl_port": {
-      "to": "9001"
-    }
-  },
-  "redirection": {
-    "redirect_naked_to_full": false,
-    "redirect_http_to_https": true
-  },
-  "custom_error_page": {
-    "error_page_template": "<html><body><h1>$TITLE$</h1><div>$BODY$</div></body></html>",
-    "custom_error_page_templates": {
-      "error.type.connection_timeout": "<html><body><h1>$TITLE$</h1><div>$BODY$</div></body></html>",
-      "error.type.access_denied": "<html><body><h1>$TITLE$</h1><div>$BODY$</div></body></html>"
-    }
-  }
-}
-`))
+		if req.URL.String() == applicationDeliveryEndpoint {
+			rw.Write([]byte(`
+				{
+				"compression": {
+					"file_compression": true,
+					"compression_type": "GZIP",
+					"minify_js": true,
+					"minify_css": false,
+					"minify_static_html": true
+				},
+				"image_compression": {
+					"compress_jpeg": true,
+					"progressive_image_rendering": true,
+					"aggressive_compression": false,
+					"compress_png": true
+				},
+				"network": {
+					"tcp_pre_pooling": true,
+					"origin_connection_reuse": false,
+					"support_non_sni_clients": true,
+					"port": {
+					"to": "8080"
+					},
+					"ssl_port": {
+					"to": "9001"
+					}
+				},
+				"redirection": {
+					"redirect_naked_to_full": false,
+					"redirect_http_to_https": true
+				}
+				}
+			`))
+		} else {
+			rw.Write([]byte(`
+				{
+					"custom_error_page": {
+					"error_page_template": "<html><body><h1>$TITLE$</h1><div>$BODY$</div></body></html>",
+					"custom_error_page_templates": {
+						"error.type.connection_timeout": "<html><body><h1>$TITLE$</h1><div>$BODY$</div></body></html>",
+						"error.type.access_denied": "<html><body><h1>$TITLE$</h1><div>$BODY$</div></body></html>"
+					}
+					}
+				}
+			`))
+		}
 	}))
 	defer server.Close()
 
 	config := &Config{APIID: apiID, APIKey: apiKey, BaseURL: server.URL, BaseURLRev2: server.URL, BaseURLAPI: server.URL}
 	client := &Client{config: config, httpClient: &http.Client{}}
+
 	payload := ApplicationDelivery{
 		Compression:      Compression{},
 		ImageCompression: ImageCompression{},
 		Network:          Network{},
 		Redirection:      Redirection{},
-		CustomErrorPage:  CustomErrorPage{},
 	}
 
-	applicationDeliveryResponse, err := client.UpdateApplicationDelivery(
+	customErrorPagesPayload := CustomErrorPage{}
+
+	applicationDeliveryResponse, diags := client.UpdateApplicationDelivery(
 		siteID,
 		&payload)
 
-	if err != nil {
-		t.Errorf("Should not have received an error : %s", err.Error())
+	if diags != nil {
+		t.Errorf("Should not have received an error : %s", diags[0].Detail)
 	}
 	if applicationDeliveryResponse.Network.SupportNonSniClients != true {
 		t.Errorf("Should have received a SupportNonSniClients equal true\n%v", applicationDeliveryResponse)
+	}
+
+	errorPages, diags := client.UpdateErrorPages(
+		siteID,
+		&customErrorPagesPayload)
+	if diags != nil {
+		t.Errorf("Should not have received an error : %s", diags[0].Detail)
+	}
+	if errorPages.DefaultErrorPage == "" || errorPages.CustomErrorPageTemplates.ErrorConnectionTimeout == "" || errorPages.CustomErrorPageTemplates.ErrorConnectionFailed != "" || errorPages.DefaultErrorPage != "<html><body><h1>$TITLE$</h1><div>$BODY$</div></body></html>" {
+		t.Errorf("unexpected error page response: %v", errorPages)
 	}
 }
 
@@ -217,11 +273,17 @@ func TestReadApplicationDeliveryBadConnection(t *testing.T) {
 	if err == nil {
 		t.Errorf("Should have received an error")
 	}
-	if !strings.HasPrefix(err.Error(), "[ERROR] Error from Incapsula service when trying to read Application Delivery for Site ID 42") {
-		t.Errorf("Should have received an client error, got: %s", err)
-	}
 	if applicationDeliveryResponse != nil {
 		t.Errorf("Should have received a nil applicationDeliveryResponse instance")
+	}
+
+	errorPages, err := client.GetErrorPages(siteID)
+
+	if err == nil {
+		t.Errorf("Should have received an error")
+	}
+	if errorPages != nil {
+		t.Errorf("Should have received a nil errorPages instance")
 	}
 }
 
@@ -230,11 +292,12 @@ func TestReadApplicationDeliveryBadJSON(t *testing.T) {
 	apiKey := "bar"
 	siteID := 42
 
-	endpoint := fmt.Sprintf("/sites/%d/settings/delivery", siteID)
+	applicationDeliveryEndpoint := fmt.Sprintf("/sites/%d/settings/delivery", siteID)
+	errorPagesEndpoint := fmt.Sprintf("/sites/%d/settings/delivery/error-pages", siteID)
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		if req.URL.String() != endpoint {
-			t.Errorf("Should have have hit %s endpoint. Got: %s", endpoint, req.URL.String())
+		if req.URL.String() != applicationDeliveryEndpoint && req.URL.String() != errorPagesEndpoint {
+			t.Errorf("Should have have hit delivery settings endpoint. Got: %s", req.URL.String())
 		}
 		rw.Write([]byte(`{`))
 	}))
@@ -248,11 +311,17 @@ func TestReadApplicationDeliveryBadJSON(t *testing.T) {
 	if err == nil {
 		t.Errorf("Should have received an error")
 	}
-	if !strings.HasPrefix(err.Error(), "[ERROR] Error parsing Application Delivery Response JSON response for Site ID") {
-		t.Errorf("Should have received an client error, got: %s", err)
-	}
 	if applicationDeliveryResponse != nil {
 		t.Errorf("Should have received a nil applicationDeliveryResponse instance")
+	}
+
+	errorPages, err := client.GetErrorPages(siteID)
+
+	if err == nil {
+		t.Errorf("Should have received an error")
+	}
+	if errorPages != nil {
+		t.Errorf("Should have received a nil errorPages instance")
 	}
 
 }
@@ -262,12 +331,13 @@ func TestReadApplicationDeliveryInvalidConfig(t *testing.T) {
 	apiKey := "bar"
 	siteID := 42
 
-	endpoint := fmt.Sprintf("/sites/%d/settings/delivery", siteID)
+	applicationDeliveryEndpoint := fmt.Sprintf("/sites/%d/settings/delivery", siteID)
+	errorPagesEndpoint := fmt.Sprintf("/sites/%d/settings/delivery/error-pages", siteID)
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(500)
-		if req.URL.String() != endpoint {
-			t.Errorf("Should have have hit %s endpoint. Got: %s", endpoint, req.URL.String())
+		if req.URL.String() != applicationDeliveryEndpoint && req.URL.String() != errorPagesEndpoint {
+			t.Errorf("Should have have hit delivery settings endpoint. Got: %s", req.URL.String())
 		}
 		rw.Write([]byte(`{
   "errors": [
@@ -287,17 +357,28 @@ func TestReadApplicationDeliveryInvalidConfig(t *testing.T) {
 	config := &Config{APIID: apiID, APIKey: apiKey, BaseURL: server.URL, BaseURLRev2: server.URL, BaseURLAPI: server.URL}
 	client := &Client{config: config, httpClient: &http.Client{}}
 
-	applicationDeliveryResponse, err := client.GetApplicationDelivery(siteID)
+	applicationDeliveryResponse, diags := client.GetApplicationDelivery(siteID)
 
-	if err == nil {
+	if diags == nil {
 		t.Errorf("Should have received an error")
 	}
-	if !strings.HasPrefix(err.Error(), fmt.Sprintf("Error status code 500 from Incapsula service when Reading Application Delivery for Site ID")) {
-		t.Errorf("Should have received an internal server error for Application Delivery, got: %s", err)
+	if !strings.HasPrefix(diags[0].Detail, fmt.Sprintf("Error status code %d from Incapsula service when %s Application Delivery for Site ID %d", 500, siteID)) {
+		t.Errorf("Should have received a bad Application Delivery error, got: %s", diags[0].Detail)
 	}
-
 	if applicationDeliveryResponse != nil {
 		t.Errorf("Should have received a nil applicationDeliveryResponse instance")
+	}
+
+	errorPages, diags := client.GetErrorPages(siteID)
+
+	if diags == nil {
+		t.Errorf("Should have received an error")
+	}
+	if !strings.HasPrefix(diags[0].Detail, fmt.Sprintf("Error status code %d from Incapsula service when %s Error Pages for Site ID %d", 500, siteID)) {
+		t.Errorf("Should have received a bad Application Delivery error, got: %s", diags[0].Detail)
+	}
+	if errorPages != nil {
+		t.Errorf("Should have received a nil errorPages instance")
 	}
 }
 
@@ -478,7 +559,7 @@ func TestDeleteApplicationDeliveryConfig(t *testing.T) {
 	config := &Config{APIID: apiID, APIKey: apiKey, BaseURL: server.URL, BaseURLRev2: server.URL, BaseURLAPI: server.URL}
 	client := &Client{config: config, httpClient: &http.Client{}}
 
-	_, err := client.DeleteApplicationDelivery(
+	_, _, err := client.DeleteApplicationDelivery(
 		siteID)
 
 	if err != nil {

--- a/incapsula/client_application_delivery_test.go
+++ b/incapsula/client_application_delivery_test.go
@@ -140,7 +140,7 @@ func TestUpdateApplicationDeliveryInvalidConfig(t *testing.T) {
 	if diags == nil {
 		t.Errorf("Should have received an error")
 	}
-	if !strings.HasPrefix(diags[0].Detail, fmt.Sprintf("Error status code %d from Incapsula service when %s Application Delivery for Site ID %d", 500, siteID)) {
+	if !strings.HasPrefix(diags[0].Detail, fmt.Sprintf("Error status code %d from Incapsula service when Updating Application Delivery for Site ID %d", 500, siteID)) {
 		t.Errorf("Should have received a bad Application Delivery error, got: %s", diags[0].Detail)
 	}
 	if applicationDeliveryResponse != nil {
@@ -156,7 +156,7 @@ func TestUpdateApplicationDeliveryInvalidConfig(t *testing.T) {
 	if diags == nil {
 		t.Errorf("Should have received an error")
 	}
-	if !strings.HasPrefix(diags[0].Detail, fmt.Sprintf("Error status code %d from Incapsula service when %s Error Pages for Site ID %d", 500, siteID)) {
+	if !strings.HasPrefix(diags[0].Detail, fmt.Sprintf("Error status code %d from Incapsula service when Updating Error Pages for Site ID %d", 500, siteID)) {
 		t.Errorf("Should have received a bad Application Delivery error, got: %s", diags[0].Detail)
 	}
 	if errorPages != nil {
@@ -213,12 +213,10 @@ func TestUpdateApplicationDeliveryConfig(t *testing.T) {
 		} else {
 			rw.Write([]byte(`
 				{
-					"custom_error_page": {
 					"error_page_template": "<html><body><h1>$TITLE$</h1><div>$BODY$</div></body></html>",
 					"custom_error_page_templates": {
 						"error.type.connection_timeout": "<html><body><h1>$TITLE$</h1><div>$BODY$</div></body></html>",
 						"error.type.access_denied": "<html><body><h1>$TITLE$</h1><div>$BODY$</div></body></html>"
-					}
 					}
 				}
 			`))
@@ -362,7 +360,7 @@ func TestReadApplicationDeliveryInvalidConfig(t *testing.T) {
 	if diags == nil {
 		t.Errorf("Should have received an error")
 	}
-	if !strings.HasPrefix(diags[0].Detail, fmt.Sprintf("Error status code %d from Incapsula service when %s Application Delivery for Site ID %d", 500, siteID)) {
+	if !strings.HasPrefix(diags[0].Detail, fmt.Sprintf("Error status code %d from Incapsula service when Reading Application Delivery for Site ID %d", 500, siteID)) {
 		t.Errorf("Should have received a bad Application Delivery error, got: %s", diags[0].Detail)
 	}
 	if applicationDeliveryResponse != nil {
@@ -374,7 +372,7 @@ func TestReadApplicationDeliveryInvalidConfig(t *testing.T) {
 	if diags == nil {
 		t.Errorf("Should have received an error")
 	}
-	if !strings.HasPrefix(diags[0].Detail, fmt.Sprintf("Error status code %d from Incapsula service when %s Error Pages for Site ID %d", 500, siteID)) {
+	if !strings.HasPrefix(diags[0].Detail, fmt.Sprintf("Error status code %d from Incapsula service when Reading Error Pages for Site ID %d", 500, siteID)) {
 		t.Errorf("Should have received a bad Application Delivery error, got: %s", diags[0].Detail)
 	}
 	if errorPages != nil {
@@ -438,10 +436,10 @@ func TestReadApplicationDeliveryConfig(t *testing.T) {
 	config := &Config{APIID: apiID, APIKey: apiKey, BaseURL: server.URL, BaseURLRev2: server.URL, BaseURLAPI: server.URL}
 	client := &Client{config: config, httpClient: &http.Client{}}
 
-	applicationDeliveryResponse, err := client.GetApplicationDelivery(siteID)
+	applicationDeliveryResponse, diags := client.GetApplicationDelivery(siteID)
 
-	if err != nil {
-		t.Errorf("Should not have received an error : %s", err.Error())
+	if diags != nil {
+		t.Errorf("Should not have received an error : %s", diags[0].Detail)
 	}
 	if applicationDeliveryResponse == nil {
 		t.Errorf("Should not have received a nil applicationDeliveryResponse instance")
@@ -463,9 +461,6 @@ func TestDeleteApplicationDeliveryBadConnection(t *testing.T) {
 
 	if err == nil {
 		t.Errorf("Should have received an error")
-	}
-	if !strings.HasPrefix(err.Error(), "[ERROR] Error from Incapsula service when trying to delete Application Delivery for Site ID 42:") {
-		t.Errorf("Should have received an client error, got: %s", err)
 	}
 	if applicationDeliveryResponse != nil {
 		t.Errorf("Should have received a nil applicationDeliveryResponse instance")
@@ -494,9 +489,6 @@ func TestDeleteApplicationDeliveryBadJSON(t *testing.T) {
 
 	if err == nil {
 		t.Errorf("Should have received an error")
-	}
-	if !strings.HasPrefix(err.Error(), "[ERROR] Error parsing Application Delivery Response JSON response for Site ID") {
-		t.Errorf("Should have received an client error, got: %s", err)
 	}
 	if applicationDeliveryResponse != nil {
 		t.Errorf("Should have received a nil applicationDeliveryResponse instance")
@@ -528,10 +520,6 @@ func TestDeleteApplicationDeliveryInvalidConfig(t *testing.T) {
 	if err == nil {
 		t.Errorf("Should have received an error")
 	}
-	if !strings.HasPrefix(err.Error(), fmt.Sprintf("Error status code 500 from Incapsula service when Deleting Application Delivery for Site ID")) {
-		t.Errorf("Should have received an internal server error for Application Delivery, got: %s", err)
-	}
-
 	if applicationDeliveryResponse != nil {
 		t.Errorf("Should have received a nil applicationDeliveryResponse instance")
 	}
@@ -559,8 +547,7 @@ func TestDeleteApplicationDeliveryConfig(t *testing.T) {
 	config := &Config{APIID: apiID, APIKey: apiKey, BaseURL: server.URL, BaseURLRev2: server.URL, BaseURLAPI: server.URL}
 	client := &Client{config: config, httpClient: &http.Client{}}
 
-	_, _, err := client.DeleteApplicationDelivery(
-		siteID)
+	_, err := client.DeleteApplicationDelivery(siteID)
 
 	if err != nil {
 		t.Errorf("Should not have received an error")

--- a/incapsula/resource_application_delivery.go
+++ b/incapsula/resource_application_delivery.go
@@ -425,21 +425,6 @@ func resourceApplicationDeliveryUpdate(ctx context.Context, d *schema.ResourceDa
 		RedirectHttpToHttps: d.Get("redirect_http_to_https").(bool),
 	}
 
-	customErrorPage := CustomErrorPage{
-		DefaultErrorPage: d.Get("default_error_page_template").(string),
-		CustomErrorPageTemplates: CustomErrorPageTemplates{
-			ErrorConnectionTimeout:       d.Get("error_connection_timeout").(string),
-			ErrorAccessDenied:            d.Get("error_access_denied").(string),
-			ErrorParseReqError:           d.Get("error_parse_req_error").(string),
-			ErrorParseRespError:          d.Get("error_parse_resp_error").(string),
-			ErrorConnectionFailed:        d.Get("error_connection_failed").(string),
-			ErrorSslFailed:               d.Get("error_ssl_failed").(string),
-			ErrorDenyAndCaptcha:          d.Get("error_deny_and_captcha").(string),
-			ErrorTypeNoSslConfig:         d.Get("error_no_ssl_config").(string),
-			ErrorAbpIdentificationFailed: d.Get("error_abp_identification_failed").(string),
-		},
-	}
-
 	payload := ApplicationDelivery{
 		Compression:      compression,
 		ImageCompression: imageCompression,
@@ -464,6 +449,22 @@ func resourceApplicationDeliveryUpdate(ctx context.Context, d *schema.ResourceDa
 		d.HasChange("error_deny_and_captcha") ||
 		d.HasChange("error_no_ssl_config") ||
 		d.HasChange("error_abp_identification_failed") {
+
+		customErrorPage := CustomErrorPage{
+			DefaultErrorPage: d.Get("default_error_page_template").(string),
+			CustomErrorPageTemplates: CustomErrorPageTemplates{
+				ErrorConnectionTimeout:       d.Get("error_connection_timeout").(string),
+				ErrorAccessDenied:            d.Get("error_access_denied").(string),
+				ErrorParseReqError:           d.Get("error_parse_req_error").(string),
+				ErrorParseRespError:          d.Get("error_parse_resp_error").(string),
+				ErrorConnectionFailed:        d.Get("error_connection_failed").(string),
+				ErrorSslFailed:               d.Get("error_ssl_failed").(string),
+				ErrorDenyAndCaptcha:          d.Get("error_deny_and_captcha").(string),
+				ErrorTypeNoSslConfig:         d.Get("error_no_ssl_config").(string),
+				ErrorAbpIdentificationFailed: d.Get("error_abp_identification_failed").(string),
+			},
+		}
+
 		_, diags := client.UpdateErrorPages(siteID, &customErrorPage)
 
 		if diags != nil {

--- a/incapsula/resource_application_delivery.go
+++ b/incapsula/resource_application_delivery.go
@@ -1,11 +1,13 @@
 package incapsula
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strconv"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -15,10 +17,10 @@ const defaultSslPortTo = 443
 
 func resourceApplicationDelivery() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceApplicationDeliveryUpdate,
-		Read:   resourceApplicationDeliveryRead,
-		Update: resourceApplicationDeliveryUpdate,
-		Delete: resourceApplicationDeliveryDelete,
+		CreateContext: resourceApplicationDeliveryUpdate,
+		ReadContext:   resourceApplicationDeliveryRead,
+		UpdateContext: resourceApplicationDeliveryUpdate,
+		DeleteContext: resourceApplicationDeliveryDelete,
 		Importer: &schema.ResourceImporter{
 			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 				siteID, err := strconv.Atoi(d.Id())
@@ -305,15 +307,21 @@ func resourceApplicationDelivery() *schema.Resource {
 	}
 }
 
-func resourceApplicationDeliveryRead(d *schema.ResourceData, m interface{}) error {
+func resourceApplicationDeliveryRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*Client)
 	siteID := d.Get("site_id").(int)
 	siteIdStr := strconv.Itoa(siteID)
 
-	applicationDelivery, err := client.GetApplicationDelivery(siteID)
-	if err != nil {
-		log.Printf("[ERROR] Could not get Incapsula Application Delivery for Site Id: %d - %s\n", siteID, err)
-		return err
+	applicationDelivery, diag := client.GetApplicationDelivery(siteID)
+	if diag != nil {
+		log.Printf("[ERROR] Could not get Incapsula Application Delivery for Site Id: %d\n", siteID)
+		return diag
+	}
+
+	errorPages, diag := client.GetErrorPages(siteID)
+	if diag != nil {
+		log.Printf("[ERROR] Could not get Incapsula Error Pages for Site Id: %d\n", siteID)
+		return diag
 	}
 
 	d.SetId(siteIdStr)
@@ -347,21 +355,22 @@ func resourceApplicationDeliveryRead(d *schema.ResourceData, m interface{}) erro
 	d.Set("redirect_naked_to_full", applicationDelivery.Redirection.RedirectNakedToFull)
 	d.Set("redirect_http_to_https", applicationDelivery.Redirection.RedirectHttpToHttps)
 
-	d.Set("default_error_page_template", strings.ReplaceAll(applicationDelivery.CustomErrorPage.DefaultErrorPage, "'", "\""))
-	d.Set("error_connection_timeout", strings.ReplaceAll(applicationDelivery.CustomErrorPage.CustomErrorPageTemplates.ErrorConnectionTimeout, "'", "\""))
-	d.Set("error_access_denied", strings.ReplaceAll(applicationDelivery.CustomErrorPage.CustomErrorPageTemplates.ErrorAccessDenied, "'", "\""))
-	d.Set("error_parse_req_error", strings.ReplaceAll(applicationDelivery.CustomErrorPage.CustomErrorPageTemplates.ErrorParseReqError, "'", "\""))
-	d.Set("error_parse_resp_error", strings.ReplaceAll(applicationDelivery.CustomErrorPage.CustomErrorPageTemplates.ErrorParseRespError, "'", "\""))
-	d.Set("error_connection_failed", strings.ReplaceAll(applicationDelivery.CustomErrorPage.CustomErrorPageTemplates.ErrorConnectionFailed, "'", "\""))
-	d.Set("error_ssl_failed", strings.ReplaceAll(applicationDelivery.CustomErrorPage.CustomErrorPageTemplates.ErrorSslFailed, "'", "\""))
-	d.Set("error_deny_and_captcha", strings.ReplaceAll(applicationDelivery.CustomErrorPage.CustomErrorPageTemplates.ErrorDenyAndCaptcha, "'", "\""))
-	d.Set("error_no_ssl_config", strings.ReplaceAll(applicationDelivery.CustomErrorPage.CustomErrorPageTemplates.ErrorTypeNoSslConfig, "'", "\""))
-	d.Set("error_abp_identification_failed", strings.ReplaceAll(applicationDelivery.CustomErrorPage.CustomErrorPageTemplates.ErrorAbpIdentificationFailed, "'", "\""))
+	d.Set("default_error_page_template", strings.ReplaceAll(errorPages.DefaultErrorPage, "'", "\""))
+	d.Set("error_connection_timeout", strings.ReplaceAll(errorPages.CustomErrorPageTemplates.ErrorConnectionTimeout, "'", "\""))
+	d.Set("error_access_denied", strings.ReplaceAll(errorPages.CustomErrorPageTemplates.ErrorAccessDenied, "'", "\""))
+	d.Set("error_parse_req_error", strings.ReplaceAll(errorPages.CustomErrorPageTemplates.ErrorParseReqError, "'", "\""))
+	d.Set("error_parse_resp_error", strings.ReplaceAll(errorPages.CustomErrorPageTemplates.ErrorParseRespError, "'", "\""))
+	d.Set("error_connection_failed", strings.ReplaceAll(errorPages.CustomErrorPageTemplates.ErrorConnectionFailed, "'", "\""))
+	d.Set("error_ssl_failed", strings.ReplaceAll(errorPages.CustomErrorPageTemplates.ErrorSslFailed, "'", "\""))
+	d.Set("error_deny_and_captcha", strings.ReplaceAll(errorPages.CustomErrorPageTemplates.ErrorDenyAndCaptcha, "'", "\""))
+	d.Set("error_no_ssl_config", strings.ReplaceAll(errorPages.CustomErrorPageTemplates.ErrorTypeNoSslConfig, "'", "\""))
+	d.Set("error_abp_identification_failed", strings.ReplaceAll(errorPages.CustomErrorPageTemplates.ErrorAbpIdentificationFailed, "'", "\""))
 
 	return nil
 }
 
-func resourceApplicationDeliveryUpdate(d *schema.ResourceData, m interface{}) error {
+func resourceApplicationDeliveryUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	client := m.(*Client)
 	siteID := d.Get("site_id").(int)
 	http2 := new(bool)
@@ -374,11 +383,12 @@ func resourceApplicationDeliveryUpdate(d *schema.ResourceData, m interface{}) er
 		http2ToOrigin = nil
 	} else {
 		if !d.Get("enable_http2").(bool) && d.Get("http2_to_origin").(bool) {
-			log.Printf("[ERROR] error in Application Delivery resource - " +
-				"HTTP/2 to Origin support requires that HTTP/2 will be enabled for your website")
-
-			return fmt.Errorf("error in Application Delivery resource - " +
-				"HTTP/2 to Origin support requires that HTTP/2 will be enabled for your website")
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  "[ERROR] error in Application Delivery resource",
+				Detail:   "HTTP/2 to Origin support requires that HTTP/2 will be enabled for your website",
+			})
+			return diags
 		} else {
 			*http2 = d.Get("enable_http2").(bool)
 			*http2ToOrigin = d.Get("http2_to_origin").(bool)
@@ -414,6 +424,7 @@ func resourceApplicationDeliveryUpdate(d *schema.ResourceData, m interface{}) er
 		RedirectNakedToFull: d.Get("redirect_naked_to_full").(bool),
 		RedirectHttpToHttps: d.Get("redirect_http_to_https").(bool),
 	}
+
 	customErrorPage := CustomErrorPage{
 		DefaultErrorPage: d.Get("default_error_page_template").(string),
 		CustomErrorPageTemplates: CustomErrorPageTemplates{
@@ -434,40 +445,43 @@ func resourceApplicationDeliveryUpdate(d *schema.ResourceData, m interface{}) er
 		ImageCompression: imageCompression,
 		Network:          network,
 		Redirection:      redirection,
-		CustomErrorPage:  customErrorPage,
 	}
 
-	_, err := client.UpdateApplicationDelivery(siteID, &payload)
+	_, diags = client.UpdateApplicationDelivery(siteID, &payload)
 
-	if err != nil {
-		log.Printf("[ERROR] Could not get Incapsula Application Delivery for Site Id: %d - %s\n", siteID, err)
-		return err
+	if diags != nil {
+		log.Printf("[ERROR] Could not update Incapsula Application Delivery for Site Id: %d - %s\n", siteID, diags[0].Detail)
+		return diags
 	}
-	return resourceApplicationDeliveryRead(d, m)
+
+	if d.HasChange("default_error_page_template") ||
+		d.HasChange("error_connection_timeout") ||
+		d.HasChange("error_access_denied") ||
+		d.HasChange("error_parse_req_error") ||
+		d.HasChange("error_parse_resp_error") ||
+		d.HasChange("error_connection_failed") ||
+		d.HasChange("error_ssl_failed") ||
+		d.HasChange("error_deny_and_captcha") ||
+		d.HasChange("error_no_ssl_config") ||
+		d.HasChange("error_abp_identification_failed") {
+		_, diags := client.UpdateErrorPages(siteID, &customErrorPage)
+
+		if diags != nil {
+			log.Printf("[ERROR] Could not get Incapsula Error Pages for Site Id: %d\n", siteID)
+			return diags
+		}
+	}
+
+	return resourceApplicationDeliveryRead(ctx, d, m)
 }
 
-func resourceApplicationDeliveryDelete(d *schema.ResourceData, m interface{}) error {
+func resourceApplicationDeliveryDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*Client)
 	siteID := d.Get("site_id").(int)
 
 	network := Network{
 		Port:    Port{To: strconv.Itoa(defaultPortTo)},
 		SslPort: SslPort{To: strconv.Itoa(defaultSslPortTo)},
-	}
-
-	customErrorPage := CustomErrorPage{
-		DefaultErrorPage: "",
-		CustomErrorPageTemplates: CustomErrorPageTemplates{
-			ErrorConnectionTimeout:       "",
-			ErrorAccessDenied:            "",
-			ErrorParseReqError:           "",
-			ErrorParseRespError:          "",
-			ErrorConnectionFailed:        "",
-			ErrorSslFailed:               "",
-			ErrorDenyAndCaptcha:          "",
-			ErrorTypeNoSslConfig:         "",
-			ErrorAbpIdentificationFailed: "",
-		},
 	}
 
 	compression := Compression{
@@ -479,22 +493,28 @@ func resourceApplicationDeliveryDelete(d *schema.ResourceData, m interface{}) er
 	}
 
 	payload := ApplicationDelivery{
-		Network:         network,
-		CustomErrorPage: customErrorPage,
-		Compression:     compression,
+		Network:     network,
+		Compression: compression,
 	}
 
-	_, err := client.UpdateApplicationDelivery(siteID, &payload)
-	if err != nil {
-		log.Printf("[ERROR] Error in Application Delivery resource for Site ID %d. Could not return values of custom error pages to defaults. Error:  %s", siteID, err)
-		return fmt.Errorf("Error in Application Delivery resource for Site ID %d. Could not return values of custom error pages to defaults. Error:  %s", siteID, err)
+	_, diags := client.UpdateApplicationDelivery(siteID, &payload)
+	if diags != nil {
+		log.Printf("[ERROR] Error in Application Delivery resource for Site ID %d. Could not return values of custom error pages to defaults.", siteID)
+		return diags
 	}
 
-	_, err = client.DeleteApplicationDelivery(siteID)
+	_, diags = client.DeleteApplicationDelivery(siteID)
 
-	if err != nil {
-		log.Printf("[ERROR] Could delete Incapsula Application Delivery for Site Id: %d - %s\n", siteID, err)
-		return err
+	if diags != nil {
+		log.Printf("[ERROR] Could delete Incapsula Application Delivery for Site Id: %d\n", siteID)
+		return diags
+	}
+
+	_, diags = client.DeleteErrorPages(siteID)
+
+	if diags != nil {
+		log.Printf("[ERROR] Could delete Incapsula Error Pages for Site Id: %d\n", siteID)
+		return diags
 	}
 
 	d.SetId("")

--- a/incapsula/resource_application_delivery_test.go
+++ b/incapsula/resource_application_delivery_test.go
@@ -2,11 +2,12 @@ package incapsula
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"log"
 	"strconv"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 const applicationDeliveryResourceName = "incapsula_application_delivery"
@@ -50,6 +51,7 @@ func TestAccIncapsulaApplicationDelivery_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(applicationDeliveryResource, "redirect_http_to_https", "false"),
 					resource.TestCheckResourceAttr(applicationDeliveryResource, "redirect_naked_to_full", "false"),
 
+					resource.TestCheckResourceAttr(applicationDeliveryResource, "default_error_page_template", customErrorPageBasic+"\n"),
 					resource.TestCheckResourceAttr(applicationDeliveryResource, "error_access_denied", customErrorPageBasic),
 				),
 			},
@@ -80,6 +82,7 @@ func TestAccIncapsulaApplicationDelivery_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(applicationDeliveryResource, "redirect_http_to_https", "false"),
 					resource.TestCheckResourceAttr(applicationDeliveryResource, "redirect_naked_to_full", "false"),
 
+					resource.TestCheckResourceAttr(applicationDeliveryResource, "default_error_page_template", ""),
 					resource.TestCheckResourceAttr(applicationDeliveryResource, "error_access_denied", customErrorPageBasic),
 				),
 			},
@@ -149,9 +152,10 @@ resource "%s" "%s" {
   tcp_pre_pooling = false
   redirect_naked_to_full = false
   redirect_http_to_https = false
+  default_error_page_template = %s
   error_access_denied         = %s
 }`,
-		applicationDeliveryResourceName, applicationDeliveryName, siteResourceName, customErrorPageInput,
+		applicationDeliveryResourceName, applicationDeliveryName, siteResourceName, customErrorPageInput, customErrorPageInput,
 	)
 }
 

--- a/incapsula/resource_application_delivery_test.go
+++ b/incapsula/resource_application_delivery_test.go
@@ -99,16 +99,16 @@ func testCheckApplicationDeliveryExists(name string) resource.TestCheckFunc {
 		if !ok {
 			return fmt.Errorf("Incapsula Application Delivery resource not found: %s", name)
 		}
-		_, err := strconv.Atoi(res.Primary.ID)
+		siteId, err := strconv.Atoi(res.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("Incapsula Application Delivery testCheckApplicationDeliveryExists: Error parsing ID %v to int", res.Primary.ID)
 		}
 
-		// client := testAccProvider.Meta().(*Client)
-		// _, err = client.GetApplicationDelivery(siteId)
-		// if err != nil {
-		// 	fmt.Errorf("Incapsula Application Delivery doesn't exist")
-		// }
+		client := testAccProvider.Meta().(*Client)
+		_, err2 := client.GetApplicationDelivery(siteId)
+		if err2 != nil {
+			fmt.Errorf("Incapsula Application Delivery doesn't exist")
+		}
 
 		return nil
 	}

--- a/incapsula/resource_application_delivery_test.go
+++ b/incapsula/resource_application_delivery_test.go
@@ -99,16 +99,16 @@ func testCheckApplicationDeliveryExists(name string) resource.TestCheckFunc {
 		if !ok {
 			return fmt.Errorf("Incapsula Application Delivery resource not found: %s", name)
 		}
-		siteId, err := strconv.Atoi(res.Primary.ID)
+		_, err := strconv.Atoi(res.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("Incapsula Application Delivery testCheckApplicationDeliveryExists: Error parsing ID %v to int", res.Primary.ID)
 		}
 
-		client := testAccProvider.Meta().(*Client)
-		_, err = client.GetApplicationDelivery(siteId)
-		if err != nil {
-			fmt.Errorf("Incapsula Application Delivery doesn't exist")
-		}
+		// client := testAccProvider.Meta().(*Client)
+		// _, err = client.GetApplicationDelivery(siteId)
+		// if err != nil {
+		// 	fmt.Errorf("Incapsula Application Delivery doesn't exist")
+		// }
 
 		return nil
 	}


### PR DESCRIPTION
The current request of application delivery does partial update, thus making it impossible to "unset" error pages.
Adding a full update endpoint in the backend allows setting values back to null/default.
Additionally, the resource was updated to use Diagnostic as its error return.