### PR TITLE
Add optional account id parameter to the site ssl settings resource 

### DIFF
--- a/incapsula/client_site_ssl_settings.go
+++ b/incapsula/client_site_ssl_settings.go
@@ -26,7 +26,7 @@ type TLSConfiguration struct {
 }
 
 type SSLSettingsDTO struct {
-	HstsConfiguration               HSTSConfiguration                `json:"hstsConfiguration"`
+	HstsConfiguration               *HSTSConfiguration               `json:"hstsConfiguration"`
 	InboundTLSSettingsConfiguration *InboundTLSSettingsConfiguration `json:"inboundTlsSettings,omitempty"`
 }
 
@@ -34,7 +34,7 @@ type SSLSettingsResponse struct {
 	Data []SSLSettingsDTO `json:"data"`
 }
 
-func (c *Client) UpdateSiteSSLSettings(siteID int, mySSLSettings SSLSettingsResponse) (*SSLSettingsResponse, error) {
+func (c *Client) UpdateSiteSSLSettings(siteID int, accountID int, mySSLSettings SSLSettingsResponse) (*SSLSettingsResponse, error) {
 	log.Printf("[INFO] Updating Incapsula Site SSL settings for Site ID %d\n", siteID)
 
 	requestJSON, err := json.Marshal(mySSLSettings)
@@ -44,6 +44,9 @@ func (c *Client) UpdateSiteSSLSettings(siteID int, mySSLSettings SSLSettingsResp
 
 	// Patch request to Incapsula
 	reqURL := fmt.Sprintf("%s/sites-mgmt/v3/sites/%d/settings/TLSConfiguration", c.config.BaseURLAPI, siteID)
+	if accountID != 0 {
+		reqURL = fmt.Sprintf("%s?caid=%d", reqURL, accountID)
+	}
 	log.Printf("[INFO] SSL Settings request json looks like this %s\n", requestJSON)
 	log.Printf("[INFO] SSL Settings request URL looks like this %s\n", reqURL)
 	resp, err := c.DoJsonRequestWithHeaders(http.MethodPatch, reqURL, requestJSON, UpdateSiteSSLSettings)
@@ -73,11 +76,15 @@ func (c *Client) UpdateSiteSSLSettings(siteID int, mySSLSettings SSLSettingsResp
 	return &sslSettingsResponse, nil
 }
 
-func (c *Client) ReadSiteSSLSettings(siteID int) (*SSLSettingsResponse, int, error) {
+func (c *Client) ReadSiteSSLSettings(siteID int, accountID int) (*SSLSettingsResponse, int, error) {
 	log.Printf("[INFO] Getting Incapsula Incap SSL settings for Site ID %d\n", siteID)
 
 	// Get form to Incapsula
 	reqURL := fmt.Sprintf("%s/sites-mgmt/v3/sites/%d/settings/TLSConfiguration", c.config.BaseURLAPI, siteID)
+	if accountID != 0 {
+		reqURL = fmt.Sprintf("%s?caid=%d", reqURL, accountID)
+	}
+	log.Printf("[INFO] SSL Settings request URL looks like this %s\n", reqURL)
 	resp, err := c.DoJsonRequestWithHeaders(http.MethodGet, reqURL, nil, ReadSiteSSLSettings)
 	if err != nil {
 		return nil, 0, fmt.Errorf("error from Incapsula service when reading SSL Settings for Site ID %d: %s", siteID, err)

--- a/incapsula/client_site_ssl_settings_test.go
+++ b/incapsula/client_site_ssl_settings_test.go
@@ -16,7 +16,7 @@ func TestUpdateSiteSSLSettingsHandleBadConnection(t *testing.T) {
 	sslSettingsDTO := getUpdateSiteSSLSettingsDTO()
 
 	// act
-	var res, err = client.UpdateSiteSSLSettings(123, sslSettingsDTO)
+	var res, err = client.UpdateSiteSSLSettings(123, 1234, sslSettingsDTO)
 
 	// assert
 	if err == nil {
@@ -33,6 +33,7 @@ func TestUpdateSiteSSLSettingsHandleResponseCodeNotSuccess(t *testing.T) {
 	apiID := "foo"
 	apiKey := "bar"
 	siteID := 42
+	accountID := 1234
 
 	endpoint := fmt.Sprintf("/sites-mgmt/v3/sites/%d/settings/TLSConfiguration", siteID)
 
@@ -53,7 +54,7 @@ func TestUpdateSiteSSLSettingsHandleResponseCodeNotSuccess(t *testing.T) {
 	var dto = getUpdateSiteSSLSettingsDTO()
 
 	// act
-	_, err := client.UpdateSiteSSLSettings(siteID, dto)
+	_, err := client.UpdateSiteSSLSettings(siteID, accountID, dto)
 
 	// assert
 	if err == nil {
@@ -70,6 +71,7 @@ func TestUpdateSiteSSLSettingsHandleInvalidResponseBody(t *testing.T) {
 	apiID := "foo"
 	apiKey := "bar"
 	siteID := 42
+	accountID := 1234
 
 	endpoint := fmt.Sprintf("/sites-mgmt/v3/sites/%d/settings/TLSConfiguration", siteID)
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
@@ -90,7 +92,7 @@ func TestUpdateSiteSSLSettingsHandleInvalidResponseBody(t *testing.T) {
 	var dto = getUpdateSiteSSLSettingsDTO()
 
 	// act
-	_, err := client.UpdateSiteSSLSettings(siteID, dto)
+	_, err := client.UpdateSiteSSLSettings(siteID, accountID, dto)
 
 	// assert
 	if err == nil {
@@ -107,6 +109,7 @@ func TestUpdateSiteSSLSettingsSuccess(t *testing.T) {
 	apiID := "foo"
 	apiKey := "bar"
 	siteID := 42
+	accountID := 1234
 
 	validResponse := getValidJSONResponse()
 
@@ -127,7 +130,7 @@ func TestUpdateSiteSSLSettingsSuccess(t *testing.T) {
 	var dto = getUpdateSiteSSLSettingsDTO()
 
 	// act
-	_, err := client.UpdateSiteSSLSettings(siteID, dto)
+	_, err := client.UpdateSiteSSLSettings(siteID, accountID, dto)
 
 	// assert
 	if err != nil {
@@ -141,7 +144,7 @@ func TestReadSiteSSLSettingsHandleRequestError(t *testing.T) {
 	client := &Client{config: config, httpClient: &http.Client{Timeout: time.Millisecond * 1}}
 
 	// act
-	var res, statusCode, err = client.ReadSiteSSLSettings(123)
+	var res, statusCode, err = client.ReadSiteSSLSettings(123, 1234)
 
 	// assert
 	if err == nil {
@@ -162,6 +165,7 @@ func TestReadSiteSSLSettingsHandleResponseCodeNotSuccess(t *testing.T) {
 	apiID := "foo"
 	apiKey := "bar"
 	siteID := 42
+	accountID := 1234
 
 	endpoint := fmt.Sprintf("/sites-mgmt/v3/sites/%d/settings/TLSConfiguration", siteID)
 
@@ -181,7 +185,7 @@ func TestReadSiteSSLSettingsHandleResponseCodeNotSuccess(t *testing.T) {
 	client := &Client{config: config, httpClient: &http.Client{}}
 
 	// act
-	_, statusCode, err := client.ReadSiteSSLSettings(siteID)
+	_, statusCode, err := client.ReadSiteSSLSettings(siteID, accountID)
 
 	// assert
 	if err == nil {
@@ -198,6 +202,7 @@ func TestReadSiteSSLSettingsHandleInvalidResponseBody(t *testing.T) {
 	apiID := "foo"
 	apiKey := "bar"
 	siteID := 42
+	accountID := 1234
 
 	endpoint := fmt.Sprintf("/sites-mgmt/v3/sites/%d/settings/TLSConfiguration", siteID)
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
@@ -217,7 +222,7 @@ func TestReadSiteSSLSettingsHandleInvalidResponseBody(t *testing.T) {
 	client := &Client{config: config, httpClient: &http.Client{}}
 
 	// act
-	_, _, err := client.ReadSiteSSLSettings(siteID)
+	_, _, err := client.ReadSiteSSLSettings(siteID, accountID)
 
 	// assert
 	if err == nil {
@@ -234,6 +239,7 @@ func TestReadSiteSSLSettingsSuccess(t *testing.T) {
 	apiID := "foo"
 	apiKey := "bar"
 	siteID := 42
+	accountID := 1234
 
 	var validResponse = getValidJSONResponse()
 
@@ -253,7 +259,7 @@ func TestReadSiteSSLSettingsSuccess(t *testing.T) {
 	client := &Client{config: config, httpClient: &http.Client{}}
 
 	// act
-	_, statusCode, err := client.ReadSiteSSLSettings(siteID)
+	_, statusCode, err := client.ReadSiteSSLSettings(siteID, accountID)
 
 	// assert
 	if err != nil {
@@ -269,7 +275,7 @@ func getUpdateSiteSSLSettingsDTO() SSLSettingsResponse {
 	var sslSettingsDTO = SSLSettingsResponse{
 		Data: []SSLSettingsDTO{
 			{
-				HstsConfiguration: HSTSConfiguration{
+				HstsConfiguration: &HSTSConfiguration{
 					PreLoaded:          true,
 					MaxAge:             1237,
 					SubDomainsIncluded: true,

--- a/website/docs/r/site_ssl_settings.html.markdown
+++ b/website/docs/r/site_ssl_settings.html.markdown
@@ -26,22 +26,30 @@ If you run the SSL settings resource from a site for which SSL is not yet enable
 resource "incapsula_site_ssl_settings" "example"  {
   site_id = incapsula_site.mysite.id
   
-  hsts {
-    is_enabled = true
-    max_age = 86400
-    sub_domains_included = true
-    pre_loaded = false
+  hsts { 
+    is_enabled               = true
+    max_age                  = 31536000
+    sub_domains_included     = false
+    pre_loaded               = false
   }
-  inbound_tls_settings { 
-    configuration_profile     = "CUSTOM"
 
-    tls_configuration { 
-      tls_version             = "TLS_1_2"
-      ciphers_support         = ["TLS_CHACHA20_POLY1305_SHA256", "TLS_AES_256_GCM_SHA384"]
+  inbound_tls_settings {
+    configuration_profile = "CUSTOM"
+
+    tls_configuration {
+      tls_version     = "TLS_1_2"
+      ciphers_support = [
+          "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+          "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+        ]
     }
-    tls_configuration { 
-      tls_version             = "TLS_1_3"
-      ciphers_support         = ["TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"]
+    tls_configuration {
+      tls_version     = "TLS_1_3"
+      ciphers_support = [
+        "TLS_AES_128_GCM_SHA256",
+        "TLS_CHACHA20_POLY1305_SHA256",
+        "TLS_AES_256_GCM_SHA384",
+      ]
     }
   }
 }
@@ -99,9 +107,10 @@ The following attributes are exported:
 
 ## Import
 
-Site SSL settings can be imported using the `id`:
+Site SSL settings can be imported using the `siteId` or `siteId`/`accountId` for sub-accounts:
 ```
 terraform import incapsula_site_ssl_settings.example 1234
+terraform import incapsula_site_ssl_settings.example 1234/4321
 ```
 
 


### PR DESCRIPTION
Add optional account id parameter to the site ssl settings resource to be able to read and update sub-account site settings