### PR TITLE
Remove left double quotation marks from Docs

### DIFF
--- a/website/docs/r/account_policy_association.html.markdown
+++ b/website/docs/r/account_policy_association.html.markdown
@@ -64,7 +64,7 @@ The following arguments are supported:
   Default setting – empty list. No default policy. Providing an empty list or omitting this argument will clear all the non-mandatory default policies.
 * `available_policy_ids` - (Optional) Comma separated list of the account’s available policies. These policies can be applied to the websites in the account.
   e.g. available_policy_ids = format(\"%s,%s\", incapsula_policy.acl1-policy.id, incapsula_policy.waf3-policy.id)
-  Specify this argument only for a parent account trying to update policy availability for its subaccounts. To remove availability for all policies, specify “NO_AVAILABLE_POLICIES”.
+  Specify this argument only for a parent account trying to update policy availability for its subaccounts. To remove availability for all policies, specify "NO_AVAILABLE_POLICIES".
   
 ## Destroy
 Destroying this resource will cause the following behavior:

--- a/website/docs/r/resource_csp_site_domain.html.markdown
+++ b/website/docs/r/resource_csp_site_domain.html.markdown
@@ -19,7 +19,7 @@ resource "incapsula_csp_site_domain" "demo-terraform-csp-site-domain" {
   domain              = "www.imperva.com"
   status              = "allowed"
   include_subdomains  = false
-  notes               = [“first note”, “second note”]
+  notes               = ["first note", "second note"]
 }
 ```
 

--- a/website/docs/r/site_monitoring.html.markdown
+++ b/website/docs/r/site_monitoring.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # incapsula_site_monitoring
 
-Configure settings to determine when origin servers should be considered “up” or “down” (active or inactive) by the Imperva Load Balancer. 
+Configure settings to determine when origin servers should be considered "up" or "down" (active or inactive) by the Imperva Load Balancer. 
 Select which failure scenarios you want to produce alarm messages, and how to send them.
 
 Note that destroy action doesn't do any change in Imperva system. To return to default values,


### PR DESCRIPTION
We are writing a [Crossplane](https://crossplane.io) provider using a tool called [upjet](https://github.com/crossplane/upjet) to generate go types from the Terraform docs. 

The use of left double quotation marks in some parts of the documentation breaks JSON parsing in upjet. This PR sets them to regular double quotes. 
