### PR TITLE
Add a parameter to enable API discovery.

### DIFF
--- a/incapsula/client_api_security_site_config.go
+++ b/incapsula/client_api_security_site_config.go
@@ -17,6 +17,7 @@ type ApiSecuritySiteConfigGetResponse struct {
 		NonApiRequestViolationAction              string           `json:"nonApiRequestViolationAction"`
 		LastModified                              int64            `json:"lastModified"`
 		ViolationActions                          ViolationActions `json:"violationActions"`
+		DiscoveryEnabled                          bool             `json:"discoveryEnabled"`
 		IsAutomaticDiscoveryApiIntegrationEnabled bool             `json:"isAutomaticDiscoveryApiIntegrationEnabled"`
 	} `json:"value"`
 	IsError bool `json:"isError"`
@@ -31,6 +32,7 @@ type ApiSecuritySiteConfigPostResponse struct {
 
 type ApiSecuritySiteConfigPostPayload struct {
 	ApiOnlySite                               bool             `json:"apiOnlySite"`
+	DiscoveryEnabled                          bool             `json:"discoveryEnabled,omitempty"`
 	IsAutomaticDiscoveryApiIntegrationEnabled bool             `json:"isAutomaticDiscoveryApiIntegrationEnabled,omitempty"`
 	NonApiRequestViolationAction              string           `json:"nonApiRequestViolationAction"`
 	ViolationActions                          ViolationActions `json:"violationActions"`

--- a/incapsula/client_api_security_site_config_test.go
+++ b/incapsula/client_api_security_site_config_test.go
@@ -19,7 +19,8 @@ func TestUpdateApiSecuritySiteConfigBadConnection(t *testing.T) {
 	siteID := 42
 
 	payload := ApiSecuritySiteConfigPostPayload{
-		ApiOnlySite: true,
+		ApiOnlySite:      true,
+		DiscoveryEnabled: true,
 		IsAutomaticDiscoveryApiIntegrationEnabled: false,
 		NonApiRequestViolationAction:              "IGNORE",
 		ViolationActions: ViolationActions{
@@ -65,7 +66,8 @@ func TestUpdateApiSecuritySiteConfigBadJSON(t *testing.T) {
 	client := &Client{config: config, httpClient: &http.Client{}}
 
 	payload := ApiSecuritySiteConfigPostPayload{
-		ApiOnlySite: true,
+		ApiOnlySite:      true,
+		DiscoveryEnabled: true,
 		IsAutomaticDiscoveryApiIntegrationEnabled: false,
 		NonApiRequestViolationAction:              "IGNORE",
 		ViolationActions: ViolationActions{
@@ -151,7 +153,8 @@ func TestUpdateApiSecuritySiteConfigValidSiteConfig(t *testing.T) {
 	config := &Config{APIID: apiID, APIKey: apiKey, BaseURL: server.URL, BaseURLRev2: server.URL, BaseURLAPI: server.URL}
 	client := &Client{config: config, httpClient: &http.Client{}}
 	payload := ApiSecuritySiteConfigPostPayload{
-		ApiOnlySite: true,
+		ApiOnlySite:      true,
+		DiscoveryEnabled: true,
 		IsAutomaticDiscoveryApiIntegrationEnabled: false,
 		NonApiRequestViolationAction:              "IGNORE",
 		ViolationActions: ViolationActions{

--- a/incapsula/resource_api_security_site_config.go
+++ b/incapsula/resource_api_security_site_config.go
@@ -33,6 +33,11 @@ func resourceApiSecuritySiteConfig() *schema.Resource {
 				Type:        schema.TypeInt,
 				Required:    true,
 			},
+			"discovery_enabled": {
+				Description: "Whether API discovery is enabled",
+				Type:        schema.TypeBool,
+				Optional:    true,
+			},
 			"is_automatic_discovery_api_integration_enabled": {
 				Description: "Parameter shows whether automatic API discovery is enabled",
 				Type:        schema.TypeBool,
@@ -102,6 +107,7 @@ func resourceApiSecuritySiteConfigUpdate(d *schema.ResourceData, m interface{}) 
 	payload := ApiSecuritySiteConfigPostPayload{
 		ApiOnlySite:                               d.Get("is_api_only_site").(bool),
 		NonApiRequestViolationAction:              d.Get("non_api_request_violation_action").(string),
+		DiscoveryEnabled:                          d.Get("discovery_enabled").(bool),
 		IsAutomaticDiscoveryApiIntegrationEnabled: d.Get("is_automatic_discovery_api_integration_enabled").(bool),
 		ViolationActions: ViolationActions{
 			InvalidUrlViolationAction:        d.Get("invalid_url_violation_action").(string),
@@ -145,6 +151,7 @@ func resourceApiSecuritySiteConfigRead(d *schema.ResourceData, m interface{}) er
 	d.Set("invalid_url_violation_action", apiSecuritySiteConfigGetResponse.Value.ViolationActions.InvalidUrlViolationAction)
 	d.Set("missing_param_violation_action", apiSecuritySiteConfigGetResponse.Value.ViolationActions.MissingParamViolationAction)
 	d.Set("non_api_request_violation_action", apiSecuritySiteConfigGetResponse.Value.NonApiRequestViolationAction)
+	d.Set("discovery_enabled", apiSecuritySiteConfigGetResponse.Value.DiscoveryEnabled)
 	d.Set("is_automatic_discovery_api_integration_enabled", apiSecuritySiteConfigGetResponse.Value.IsAutomaticDiscoveryApiIntegrationEnabled)
 	d.Set("is_api_only_site", apiSecuritySiteConfigGetResponse.Value.ApiOnlySite)
 	return nil

--- a/website/docs/r/api_security_site_config.html.markdown
+++ b/website/docs/r/api_security_site_config.html.markdown
@@ -31,6 +31,7 @@ resource "incapsula_api_security_site_config" "demo-terraform-api-security-site-
 The following arguments are supported:
 
 * `site_id` - (Required) Numeric identifier of the site to operate on.
+* `discovery_enabled` - (Optional) Whether API discovery is enabled or not.
 * `is_automatic_discovery_api_integration_enabled` - (Optional) Parameter shows whether automatic API discovery API
   Integration is enabled. This field should not be set if `API Security Add-On` subscription is not available.
 * `invalid_url_violation_action` - (Optional) The action taken when an invalid URL Violation occurs. Possible


### PR DESCRIPTION
We're trying to set up many sites entirely via Terraform, and noticed while trying to set one up with APIs that there wasn't a way to actually enable API discovery without a different manual step, so I've tried to add in that functionality here.