### PR TITLE
Fix some errors in the docs and examples for ABP

### DIFF
--- a/examples/resources/incapsula_abp_websites/resource.tf
+++ b/examples/resources/incapsula_abp_websites/resource.tf
@@ -5,14 +5,14 @@ resource "incapsula_abp_websites" "abp_websites" {
     website_group {
         name = "sites-1"
         website {
-            site_id = incapsula_site.sites-1.id
+            incapsula_site_id = incapsula_site.sites-1.id
             enable_mitigation = false
         }
     }
     website_group {
         name = "sites-2"
         website {
-            site_id = incapsula_site.sites-2.id
+            incapsula_site_id = incapsula_site.sites-2.id
             enable_mitigation = true
         }
     }
@@ -25,11 +25,11 @@ resource "incapsula_abp_websites" "abp_websites" {
     website_group {
         name = "sites"
         website {
-            site_id = incapsula_site.sites-1.id
+            incapsula_site_id = incapsula_site.sites-1.id
             enable_mitigation = false
         }
         website {
-            site_id = incapsula_site.sites-2.id
+            incapsula_site_id = incapsula_site.sites-2.id
             enable_mitigation = true
         }
     }
@@ -37,7 +37,7 @@ resource "incapsula_abp_websites" "abp_websites" {
         name = "sites" # Duplicate name
         name_id = "sites-2" # name_id can be used to disambiguate names in case of duplicates
         website {
-            site_id = incapsula_site.sites-3.id
+            incapsula_site_id = incapsula_site.sites-3.id
             enable_mitigation = true
         }
     }

--- a/website/docs/r/abp_websites.markdown
+++ b/website/docs/r/abp_websites.markdown
@@ -24,14 +24,14 @@ resource "incapsula_abp_websites" "abp_websites" {
     website_group {
         name = "sites-1"
         website {
-            site_id = incapsula_site.sites-1.id
+            incapsula_site_id = incapsula_site.sites-1.id
             enable_mitigation = false
         }
     }
     website_group {
         name = "sites-2"
         website {
-            site_id = incapsula_site.sites-2.id
+            incapsula_site_id = incapsula_site.sites-2.id
             enable_mitigation = true
         }
     }
@@ -44,11 +44,11 @@ resource "incapsula_abp_websites" "abp_websites" {
     website_group {
         name = "sites"
         website {
-            site_id = incapsula_site.sites-1.id
+            incapsula_site_id = incapsula_site.sites-1.id
             enable_mitigation = false
         }
         website {
-            site_id = incapsula_site.sites-2.id
+            incapsula_site_id = incapsula_site.sites-2.id
             enable_mitigation = true
         }
     }
@@ -56,7 +56,7 @@ resource "incapsula_abp_websites" "abp_websites" {
         name = "sites" # Duplicate name
         name_id = "sites-2" # name_id can be used to disambiguate names in case of duplicates
         website {
-            site_id = incapsula_site.sites-3.id
+            incapsula_site_id = incapsula_site.sites-3.id
             enable_mitigation = true
         }
     }


### PR DESCRIPTION
The `site_id` value should instead be `incapsula_site_id`, as mentioned later in the docs I've updated here.