### PR TITLE
Adding unknownClientsChallenge and blockNonEssentialBots

### DIFF
--- a/examples/example.tf
+++ b/examples/example.tf
@@ -444,10 +444,12 @@ resource "incapsula_security_rule_exception" "example-waf-cross-site-scripting-r
 
 # api.acl.ddos Security Rule (one instance per site)
 resource "incapsula_waf_security_rule" "example-waf-ddos-rule" {
-  site_id                = incapsula_site.example-site.id
-  rule_id                = "api.threats.ddos"
-  activation_mode        = "api.threats.ddos.activation_mode.on"
-  ddos_traffic_threshold = "5000"
+  site_id                   = incapsula_site.example-site.id
+  rule_id                   = "api.threats.ddos"
+  activation_mode           = "api.threats.ddos.activation_mode.on"
+  ddos_traffic_threshold    = "5000"
+  unknown_clients_challenge = "none"
+  block_non_essential_bots  = "false"
 }
 
 # api.threats.ddos Security Rule Sample Exception

--- a/examples/security_rules.tf
+++ b/examples/security_rules.tf
@@ -77,7 +77,9 @@ resource "incapsula_waf_security_rule" "example-waf-ddos-rule" {
   site_id                = incapsula_site.example-site.id
   rule_id                = "api.threats.ddos"
   activation_mode        = "api.threats.ddos.activation_mode.on"
-  ddos_traffic_threshold = "5000"                               
+  ddos_traffic_threshold = "5000"
+  unknown_clients_challenge = "none"
+  block_non_essential_bots  = "false"
 }
 
 ####################################################################

--- a/incapsula/client_site.go
+++ b/incapsula/client_site.go
@@ -65,16 +65,18 @@ type SiteStatusResponse struct {
 	Security                             struct {
 		Waf struct {
 			Rules []struct {
-				Action                 string `json:"action,omitempty"`
-				ActionText             string `json:"action_text,omitempty"`
-				ID                     string `json:"id"`
-				Name                   string `json:"name"`
-				BlockBadBots           bool   `json:"block_bad_bots,omitempty"`
-				ChallengeSuspectedBots bool   `json:"challenge_suspected_bots,omitempty"`
-				ActivationMode         string `json:"activation_mode,omitempty"`
-				ActivationModeText     string `json:"activation_mode_text,omitempty"`
-				DdosTrafficThreshold   int    `json:"ddos_traffic_threshold,omitempty"`
-				Exceptions             []struct {
+				Action                  string `json:"action,omitempty"`
+				ActionText              string `json:"action_text,omitempty"`
+				ID                      string `json:"id"`
+				Name                    string `json:"name"`
+				BlockBadBots            bool   `json:"block_bad_bots,omitempty"`
+				ChallengeSuspectedBots  bool   `json:"challenge_suspected_bots,omitempty"`
+				ActivationMode          string `json:"activation_mode,omitempty"`
+				ActivationModeText      string `json:"activation_mode_text,omitempty"`
+				DdosTrafficThreshold    int    `json:"ddos_traffic_threshold,omitempty"`
+				UnknownClientsChallenge string `json:"unknown_clients_challenge,omitempty"`
+				BlockNonEssentialBots   bool   `json:"block_non_essential_bots,omitempty"`
+				Exceptions              []struct {
 					Values []struct {
 						ID   string   `json:"id,omitempty"`
 						Name string   `json:"name,omitempty"`

--- a/incapsula/client_waf_security_rule.go
+++ b/incapsula/client_waf_security_rule.go
@@ -23,7 +23,7 @@ const botAccessControlRuleID = "api.threats.bot_access_control"
 const customRuleDefaultActionID = "api.threats.customRule"
 
 // ConfigureWAFSecurityRule adds an WAF rule
-func (c *Client) ConfigureWAFSecurityRule(siteID int, ruleID, securityRuleAction, activationMode, ddosTrafficThreshold, blockBadBots, challengeSuspectedBots string) (*SiteStatusResponse, error) {
+func (c *Client) ConfigureWAFSecurityRule(siteID int, ruleID, securityRuleAction, activationMode, ddosTrafficThreshold, unknownClientsChallenge, blockNonEssentialBots, blockBadBots, challengeSuspectedBots string) (*SiteStatusResponse, error) {
 	// Base URL values
 	values := url.Values{
 		"site_id": {strconv.Itoa(siteID)},
@@ -37,7 +37,14 @@ func (c *Client) ConfigureWAFSecurityRule(siteID int, ruleID, securityRuleAction
 	} else if ruleID == ddosRuleID {
 		values.Add("activation_mode", activationMode)
 		values.Add("ddos_traffic_threshold", ddosTrafficThreshold)
-		log.Printf("[INFO] Configuring Incapsula WAF rule id (%s) with activation mode (%s) and DDoS traffic threshold (%s) for site id (%d)\n", ruleID, activationMode, ddosTrafficThreshold, siteID)
+
+		if unknownClientsChallenge != "" {
+			values.Add("unknown_clients_challenge", unknownClientsChallenge)
+		}
+		if blockNonEssentialBots != "" {
+			values.Add("block_non_essential_bots", blockNonEssentialBots)
+		}
+		log.Printf("[INFO] Configuring Incapsula WAF rule id (%s) with activation mode (%s), DDoS traffic threshold (%s), unknown clients challenge (%s) and block non essential bots (%s) for site id (%d)\n", ruleID, activationMode, ddosTrafficThreshold, unknownClientsChallenge, blockNonEssentialBots, siteID)
 	} else if ruleID == botAccessControlRuleID {
 		values.Add("block_bad_bots", blockBadBots)
 		values.Add("challenge_suspected_bots", challengeSuspectedBots)

--- a/incapsula/client_waf_security_rule_test.go
+++ b/incapsula/client_waf_security_rule_test.go
@@ -22,7 +22,7 @@ func TestClientConfigureWAFSecurityRuleBadConnection(t *testing.T) {
 	siteID := 1234
 	ruleID := "api.threats.backdoor"
 	securityRuleAction := "badRuleAction"
-	configureWAFSecurityRuleResponse, err := client.ConfigureWAFSecurityRule(siteID, ruleID, securityRuleAction, "", "", "", "")
+	configureWAFSecurityRuleResponse, err := client.ConfigureWAFSecurityRule(siteID, ruleID, securityRuleAction, "", "", "", "", "", "")
 	if err == nil {
 		t.Errorf("Should have received an error")
 	}
@@ -50,7 +50,7 @@ func TestClientConfigureWAFSecurityRuleBadJSON(t *testing.T) {
 	siteID := 1234
 	ruleID := "api.threats.backdoor"
 	securityRuleAction := "badRuleAction"
-	configureWAFSecurityRuleResponse, err := client.ConfigureWAFSecurityRule(siteID, ruleID, securityRuleAction, "", "", "", "")
+	configureWAFSecurityRuleResponse, err := client.ConfigureWAFSecurityRule(siteID, ruleID, securityRuleAction, "", "", "", "", "", "")
 	if err == nil {
 		t.Errorf("Should have received an error")
 	}
@@ -78,7 +78,7 @@ func TestClientConfigureWAFSecurityRuleInvalidRuleID(t *testing.T) {
 	siteID := 1234
 	ruleID := "bad_rule_id"
 	securityRuleAction := "bad_rule_action"
-	configureWAFSecurityRuleResponse, err := client.ConfigureWAFSecurityRule(siteID, ruleID, securityRuleAction, "", "", "", "")
+	configureWAFSecurityRuleResponse, err := client.ConfigureWAFSecurityRule(siteID, ruleID, securityRuleAction, "", "", "", "", "", "")
 	if err == nil {
 		t.Errorf("Should have received an error")
 	}
@@ -106,7 +106,7 @@ func TestClientConfigureWAFSecurityRuleInvalidRuleAction(t *testing.T) {
 	siteID := 1234
 	ruleID := "api.threats.backdoor"
 	securityRuleAction := "bad_rule_action"
-	configureWAFSecurityRuleResponse, err := client.ConfigureWAFSecurityRule(siteID, ruleID, securityRuleAction, "", "", "", "")
+	configureWAFSecurityRuleResponse, err := client.ConfigureWAFSecurityRule(siteID, ruleID, securityRuleAction, "", "", "", "", "", "")
 	if err == nil {
 		t.Errorf("Should have received an error")
 	}
@@ -135,7 +135,9 @@ func TestClientConfigureWAFSecurityRuleInvalidRule_activationMode(t *testing.T) 
 	ruleID := backdoorRuleID
 	activationMode := "api.threats.ddos.activation_mode.on"
 	ddosTrafficThreshold := "123"
-	configureWAFSecurityRuleResponse, err := client.ConfigureWAFSecurityRule(siteID, ruleID, "", activationMode, ddosTrafficThreshold, "", "")
+	unknownClientsChallenge := "none"
+	blockNonEssentialBots := "false"
+	configureWAFSecurityRuleResponse, err := client.ConfigureWAFSecurityRule(siteID, ruleID, "", activationMode, ddosTrafficThreshold, unknownClientsChallenge, blockNonEssentialBots, "", "")
 	if err == nil {
 		t.Errorf("Should have received an error")
 	}
@@ -164,7 +166,9 @@ func TestClientConfigureWAFSecurityRuleInvalidRule_ddosThreshold(t *testing.T) {
 	ruleID := ddosRuleID
 	activationMode := "api.threats.ddos.activation_mode.on"
 	ddosTrafficThreshold := "123"
-	configureWAFSecurityRuleResponse, err := client.ConfigureWAFSecurityRule(siteID, ruleID, "", activationMode, ddosTrafficThreshold, "", "")
+	unknownClientsChallenge := "none"
+	blockNonEssentialBots := "false"
+	configureWAFSecurityRuleResponse, err := client.ConfigureWAFSecurityRule(siteID, ruleID, "", activationMode, ddosTrafficThreshold, unknownClientsChallenge, blockNonEssentialBots, "", "")
 	if err == nil {
 		t.Errorf("Should have received an error")
 	}
@@ -193,7 +197,7 @@ func TestClientConfigureWAFSecurityRuleInvalidRule_blockBadBots(t *testing.T) {
 	ruleID := botAccessControlRuleID
 	challengeSuspectedBots := "true"
 	blockBadBots := "123"
-	configureWAFSecurityRuleResponse, err := client.ConfigureWAFSecurityRule(siteID, ruleID, "", "", "", blockBadBots, challengeSuspectedBots)
+	configureWAFSecurityRuleResponse, err := client.ConfigureWAFSecurityRule(siteID, ruleID, "", "", "", "", "", blockBadBots, challengeSuspectedBots)
 	if err == nil {
 		t.Errorf("Should have received an error")
 	}
@@ -222,7 +226,7 @@ func TestClientConfigureWAFSecurityRuleInvalidRule_challengeSuspectedBots(t *tes
 	ruleID := botAccessControlRuleID
 	challengeSuspectedBots := "123"
 	blockBadBots := "true"
-	configureWAFSecurityRuleResponse, err := client.ConfigureWAFSecurityRule(siteID, ruleID, "", "", "", blockBadBots, challengeSuspectedBots)
+	configureWAFSecurityRuleResponse, err := client.ConfigureWAFSecurityRule(siteID, ruleID, "", "", "", "", "", blockBadBots, challengeSuspectedBots)
 	if err == nil {
 		t.Errorf("Should have received an error")
 	}
@@ -254,7 +258,7 @@ func TestClientConfigureWAFSecurityRuleValidRule(t *testing.T) {
 	siteID := 1234
 	ruleID := backdoorRuleID
 	securityRuleAction := "api.threats.action.quarantine_url"
-	configureWAFSecurityRuleResponse, err := client.ConfigureWAFSecurityRule(siteID, ruleID, securityRuleAction, "", "", "", "")
+	configureWAFSecurityRuleResponse, err := client.ConfigureWAFSecurityRule(siteID, ruleID, securityRuleAction, "", "", "", "", "", "")
 	if err != nil {
 		t.Errorf("Should not have received an error")
 	}
@@ -279,7 +283,7 @@ func TestClientConfigureWAFSecurityRuleResultCodeStringValidRule(t *testing.T) {
 	siteID := 1234
 	ruleID := backdoorRuleID
 	securityRuleAction := "api.threats.action.quarantine_url"
-	configureWAFSecurityRuleResponse, err := client.ConfigureWAFSecurityRule(siteID, ruleID, securityRuleAction, "", "", "", "")
+	configureWAFSecurityRuleResponse, err := client.ConfigureWAFSecurityRule(siteID, ruleID, securityRuleAction, "", "", "", "", "", "")
 	if err != nil {
 		t.Errorf("Should not have received an error")
 	}

--- a/incapsula/resource_waf_security_rule_test.go
+++ b/incapsula/resource_waf_security_rule_test.go
@@ -239,6 +239,8 @@ resource "incapsula_waf_security_rule" "example-waf-ddos-rule" {
   rule_id = "api.threats.ddos"
   activation_mode = "api.threats.ddos.activation_mode.on"
   ddos_traffic_threshold = "5000"
+  unknown_clients_challenge = "none"
+  block_non_essential_bots  = "false"
 }`, certificateName, siteResourceName,
 	)
 }
@@ -271,6 +273,8 @@ resource "incapsula_waf_security_rule" "example-waf-ddos-rule" {
   rule_id = "api.threats.ddos"
   activation_mode = "bad_activation_mode"
   ddos_traffic_threshold = "1234"
+  unknown_clients_challenge = "none"
+  block_non_essential_bots  = "false"
 }`, certificateName, siteResourceName,
 	)
 }

--- a/website/docs/r/waf_security_rule.html.markdown
+++ b/website/docs/r/waf_security_rule.html.markdown
@@ -31,6 +31,8 @@ resource "incapsula_waf_security_rule" "example-waf-ddos-rule" {
   rule_id = "api.threats.ddos"
   activation_mode = "api.threats.ddos.activation_mode.on" # (api.threats.ddos.activation_mode.auto | api.threats.ddos.activation_mode.off | api.threats.ddos.activation_mode.on)
   ddos_traffic_threshold = "5000" # valid values are 10, 20, 50, 100, 200, 500, 750, 1000, 2000, 3000, 4000, 5000
+  unknown_clients_challenge = "none" # valid values are none, cookies, javascript, captcha (optional, default: cookies)
+  block_non_essential_bots  = "false" # true | false (optional, default: false)
 }
 ```
 
@@ -43,6 +45,8 @@ The following arguments are supported:
 * `security_rule_action` - (Optional) The action that should be taken when a threat is detected, for example: api.threats.action.block_ip. See above examples for `rule_id` and `action` combinations.
 * `activation_mode` - (Optional) The mode of activation for ddos on a site. Possible values: api.threats.ddos.activation_mode.off, api.threats.ddos.activation_mode.auto, api.threats.ddos.activation_mode.on.
 * `ddos_traffic_threshold` - (Optional) Consider site to be under DDoS if the request rate is above this threshold. The valid values are 10, 20, 50, 100, 200, 500, 750, 1000, 2000, 3000, 4000, 5000.
+* `unknown_clients_challenge` - (Optional) Defines a method used for challenging suspicious bots. This argument is valid for the rule_id api.threats.ddos argument value only. If this argument is not provided, then the value stays as it is in the system. Possible values: none, cookies, javascript, captcha
+* `block_non_essential_bots` - (Optional) If non-essential bots (bots determined to be legitimate by Imperva's client classification mechanism, such as site helpers and search engines) should be blocked or not. This argument is valid for the rule_id api.threats.ddos argument value only. If this argument is not provided, then the value stays as it is in the system. Possible values: true, false
 * `block_bad_bots` - (Optional) Whether or not to block bad bots. Possible values: true, false.
 * `challenge_suspected_bots` - (Optional) Whether or not to send a challenge to clients that are suspected to be bad bots (CAPTCHA for example). Possible values: true, false.
 


### PR DESCRIPTION
Adding unknownClientsChallenge and blockNonEssentialBots to the waf security ddos rules