### PR TITLE
clarify site versioning

### DIFF
--- a/website/docs/r/site_v3.html.markdown
+++ b/website/docs/r/site_v3.html.markdown
@@ -10,6 +10,7 @@ description: |-
 
 Provides an Incapsula V3 site resource.
 A V3 site resource is the core resource that is required by all other resources.
+incapsula_site_v3 is a newer version of incapsula_site. Site can be managed by incapsula_site_v3 or incapsula_site, but not both simultaneously.
 
 ## Example Usage
 


### PR DESCRIPTION

- Added documentation specifying that Site v3 is an updated version of Site v1.
- Noted that each site can only be managed by either Site v1 or Site v3, not both.