### PR TITLE
#CWMS-5057 Adding an example for a policy exception that's assign to a site

### DIFF
--- a/website/docs/r/policy.html.markdown
+++ b/website/docs/r/policy.html.markdown
@@ -78,6 +78,12 @@ resource "incapsula_policy" "example-waf-rule-illegal-resource-access-policy" {
               "values": [
                 "/cmd.exe"
               ]
+            },
+            {
+              "exceptionType": "SITE_ID",
+              "values": [
+              "132456789"
+              ]
             }
           ]
         }


### PR DESCRIPTION
Adding an example for a policy exception that's assign to a site