### PR TITLE
Fix Terraform crash caused by incorrect site_id usage in ManagedCertificate resource

### DIFF
--- a/incapsula/resource_bots_configuration.go
+++ b/incapsula/resource_bots_configuration.go
@@ -8,7 +8,6 @@ import (
 	"sort"
 )
 
-var siteId = "site_id"
 var canceledGoodBots = "canceled_good_bots"
 var badBots = "bad_bots"
 var botId = "id"
@@ -21,14 +20,14 @@ func resourceBotsConfiguration() *schema.Resource {
 		Delete: resourceBotsConfigurationDelete,
 		Importer: &schema.ResourceImporter{
 			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-				d.Set(siteId, d.Id())
+				d.Set("site_id", d.Id())
 				return []*schema.ResourceData{d}, nil
 			},
 		},
 
 		Schema: map[string]*schema.Schema{
 			// Required Arguments
-			siteId: {
+			"site_id": {
 				Description: "Numeric identifier of the site to operate on.",
 				Type:        schema.TypeString,
 				Required:    true,
@@ -90,19 +89,19 @@ func resourceBotsConfigurationCreate(d *schema.ResourceData, m interface{}) erro
 
 	requestDTO := populateFromConfBotsConfigurationDTO(d)
 
-	responseDTO, err := client.UpdateBotAccessControlConfiguration(d.Get(siteId).(string), requestDTO)
+	responseDTO, err := client.UpdateBotAccessControlConfiguration(d.Get("site_id").(string), requestDTO)
 	if err != nil {
 		return fmt.Errorf("Error updating Bots configuration for site (%s): %s",
-			d.Get(siteId), err)
+			d.Get("site_id"), err)
 	}
 
 	if responseDTO.Errors != nil && len(responseDTO.Errors) > 0 {
 		return fmt.Errorf("Error updating Bots configuration for site (%s): %s",
-			d.Get(siteId), responseDTO.Errors)
+			d.Get("site_id"), responseDTO.Errors)
 	}
 
 	// Set the dc ID
-	d.SetId(d.Get(siteId).(string))
+	d.SetId(d.Get("site_id").(string))
 
 	return resourceBotsConfigurationRead(d, m)
 }
@@ -111,14 +110,14 @@ func resourceBotsConfigurationRead(d *schema.ResourceData, m interface{}) error 
 	// Implement by reading the ListBotsResponse for the bots
 	client := m.(*Client)
 
-	responseDTO, err := client.GetBotAccessControlConfiguration(d.Get(siteId).(string))
+	responseDTO, err := client.GetBotAccessControlConfiguration(d.Get("site_id").(string))
 	if err != nil {
-		return fmt.Errorf("Error getting Bots configuration for site (%s): %s", d.Get(siteId), err)
+		return fmt.Errorf("Error getting Bots configuration for site (%s): %s", d.Get("site_id"), err)
 	}
 
 	if responseDTO.Errors != nil && len(responseDTO.Errors) > 0 {
 		if responseDTO.Errors[0].Status == "404" {
-			log.Printf("[INFO] Incapsula Site with ID %s has already been deleted: %s\n", d.Get(siteId), responseDTO.Errors)
+			log.Printf("[INFO] Incapsula Site with ID %s has already been deleted: %s\n", d.Get("site_id"), responseDTO.Errors)
 			d.SetId("")
 			return nil
 		}
@@ -127,7 +126,7 @@ func resourceBotsConfigurationRead(d *schema.ResourceData, m interface{}) error 
 		if err != nil {
 			panic(err)
 		}
-		return fmt.Errorf("Error getting Bots configuration for site (%s): %s", d.Get(siteId), string(out))
+		return fmt.Errorf("Error getting Bots configuration for site (%s): %s", d.Get("site_id"), string(out))
 	}
 
 	canceledGoodBotsList := make([]int, 0)
@@ -153,9 +152,9 @@ func resourceBotsConfigurationRead(d *schema.ResourceData, m interface{}) error 
 func resourceBotsConfigurationDelete(d *schema.ResourceData, m interface{}) error {
 	client := m.(*Client)
 
-	responseDTO, err := client.GetBotAccessControlConfiguration(d.Get(siteId).(string))
+	responseDTO, err := client.GetBotAccessControlConfiguration(d.Get("site_id").(string))
 	if err != nil {
-		return fmt.Errorf("Error deleting Bots configuration for site (%s): %s", d.Get(siteId), err)
+		return fmt.Errorf("Error deleting Bots configuration for site (%s): %s", d.Get("site_id"), err)
 	}
 
 	if responseDTO.Errors != nil && len(responseDTO.Errors) > 0 && responseDTO.Errors[0].Status != "404" {
@@ -163,7 +162,7 @@ func resourceBotsConfigurationDelete(d *schema.ResourceData, m interface{}) erro
 		if err != nil {
 			panic(err)
 		}
-		return fmt.Errorf("Error deleting Bots configuration for site (%s): %s", d.Get(siteId), string(out))
+		return fmt.Errorf("Error deleting Bots configuration for site (%s): %s", d.Get("site_id"), string(out))
 	}
 
 	d.SetId("")

--- a/incapsula/resource_managed_certificate.go
+++ b/incapsula/resource_managed_certificate.go
@@ -22,6 +22,8 @@ func resourceManagedCertificate() *schema.Resource {
 				client := m.(*Client)
 				parameters := strings.Split(d.Id(), "/")
 				var accountId int
+				var siteId string
+
 				var err error
 				if len(parameters) == 2 {
 					siteId = parameters[1]
@@ -72,7 +74,7 @@ func resourceManagedCertificate() *schema.Resource {
 func resourceManagedCertificateAdd(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*Client)
 	var diags diag.Diagnostics
-	siteId, _ = d.Get("site_id").(string)
+	var siteId, _ = d.Get("site_id").(string)
 	var accountId *int
 	if v, ok := d.GetOk("account_id"); ok {
 		accountIdValue := v.(int)
@@ -105,7 +107,7 @@ func resourceManagedCertificateAdd(ctx context.Context, d *schema.ResourceData, 
 func resourceManagedCertificateRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*Client)
 	var diags diag.Diagnostics
-	siteId, _ = d.Get("site_id").(string)
+	var siteId, _ = d.Get("site_id").(string)
 	var accountId *int
 	if v, ok := d.GetOk("account_id"); ok {
 		accountIdValue := v.(int)
@@ -125,8 +127,7 @@ func resourceManagedCertificateRead(ctx context.Context, d *schema.ResourceData,
 			Detail:   fmt.Sprintf("Failed to get site cert status of site ID%d, %s", id, siteCertificateV3Response.Errors[0].Detail),
 		}}
 	}
-	siteId := siteCertificateV3Response.Data[0].SiteId
-	err := d.Set("site_id", strconv.Itoa(siteId))
+	err := d.Set("site_id", strconv.Itoa(siteCertificateV3Response.Data[0].SiteId))
 	if err != nil {
 		log.Printf("[ERROR] Could not read Incapsula site id after request site cert to site ID: %d, %s\n", id, err)
 		return diag.FromErr(err)
@@ -152,7 +153,7 @@ func resourceManagedCertificateRead(ctx context.Context, d *schema.ResourceData,
 func resourceManagedCertificateDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*Client)
 	var diags diag.Diagnostics
-	siteId, _ = d.Get("site_id").(string)
+	var siteId, _ = d.Get("site_id").(string)
 	id, _ := strconv.Atoi(siteId)
 	var accountId *int
 	if v, ok := d.GetOk("account_id"); ok {

--- a/website/docs/r/domain.html.markdown
+++ b/website/docs/r/domain.html.markdown
@@ -12,7 +12,9 @@ Provides an Incapsula Domain resource for V3 Sites.
 The provider will add/delete domains to/from an Imperva site, based on this resource.
 These domains are protected by Imperva and share the website settings and configuration of the onboarded website. Legitimate traffic for all verified domains is allowed.
 
-Note: This resource is designed to work with sites represented by the "incapsula_site_v3" resource, and cannot be used together in the same configuration with the "incapsula_site_domain_configuration" resource.
+Note:
+This resource is designed to work with sites represented by the "incapsula_site_v3" resource, and cannot be used together in the same configuration with the "incapsula_site_domain_configuration" resource.
+Adding an apex domain without its corresponding www subdomain is not supported.
 
 ## Example Usage
 


### PR DESCRIPTION
Fixes an issue where Terraform crashes when creating Site, Certificate, and Bots Configuration resources.

Problem:
The Terraform crash occurred due to incorrect handling of the site_id global config in multiple resources.

Root Cause:
The site_id global config is used as a key to retrieve the site ID in Bots Configuration.
However, in the ManagedCertificate resource, siteId was mistakenly assigned the value instead of using it as a key.
This caused an unintended change where siteId transitioned from "site_id" (the key) to a numeric site ID, leading to the crash.

Fix:
use an hard coded "site_id" key
