### PR TITLE
adding deprecated flag to incapsula_site resource.

### DIFF
--- a/incapsula/resource_site.go
+++ b/incapsula/resource_site.go
@@ -1,6 +1,7 @@
 package incapsula
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strconv"
@@ -46,21 +47,35 @@ func resourceSite() *schema.Resource {
 
 			// Optional Arguments
 			"account_id": {
-				Description: "Numeric identifier of the account to operate on. If not specified, operation will be performed on the account identified by the authentication parameters.",
-				Type:        schema.TypeInt,
-				Optional:    true,
-				Computed:    true,
-				ForceNew:    true,
+				Description:      "Numeric identifier of the account to operate on. If not specified, operation will be performed on the account identified by the authentication parameters.",
+				Type:             schema.TypeInt,
+				Optional:         true,
+				Computed:         true,
+				ForceNew:         true,
+				DiffSuppressFunc: deprecatedFlagDiffSuppress(),
 			},
 			"ref_id": {
-				Description: "Customer specific identifier for this operation.",
-				Type:        schema.TypeString,
+				Description:      "Customer specific identifier for this operation.",
+				Type:             schema.TypeString,
+				Optional:         true,
+				DiffSuppressFunc: deprecatedFlagDiffSuppress(),
+			},
+			"deprecated": {
+				Description: "Once set to true, this setting is irreversible. Use true to deprecate the resource, preventing any further changes from taking effect. Deleting the resource will not remove the site. Default: false.",
+				Type:        schema.TypeBool,
 				Optional:    true,
+				Default:     false,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					oldBool, _ := strconv.ParseBool(old)
+					newBool, _ := strconv.ParseBool(new)
+					return oldBool == false && newBool == false
+				},
 			},
 			"send_site_setup_emails": {
-				Description: "If this value is false, end users will not get emails about the add site process such as DNS instructions and SSL setup.",
-				Type:        schema.TypeString,
-				Optional:    true,
+				Description:      "If this value is false, end users will not get emails about the add site process such as DNS instructions and SSL setup.",
+				Type:             schema.TypeString,
+				Optional:         true,
+				DiffSuppressFunc: deprecatedFlagDiffSuppress(),
 			},
 			"site_ip": {
 				Description: "Manually set the web server IP/CNAME.",
@@ -72,80 +87,92 @@ func resourceSite() *schema.Resource {
 					if old != "" && new != "" {
 						return true
 					}
-
-					return false
+					return d.Get("deprecated").(bool)
 				},
 			},
 			"force_ssl": {
-				Description: "If this value is true, manually set the site to support SSL. This option is only available for sites with manually configured IP/CNAME and for specific accounts.",
-				Type:        schema.TypeString,
-				Optional:    true,
+				Description:      "If this value is true, manually set the site to support SSL. This option is only available for sites with manually configured IP/CNAME and for specific accounts.",
+				Type:             schema.TypeString,
+				Optional:         true,
+				DiffSuppressFunc: deprecatedFlagDiffSuppress(),
 			},
 			"logs_account_id": {
-				Description: "Available only for Enterprise Plan customers that purchased the Logs Integration SKU. Numeric identifier of the account that purchased the logs integration SKU and which collects the logs. If not specified, operation will be performed on the account identified by the authentication parameters.",
-				Type:        schema.TypeString,
-				Optional:    true,
+				Description:      "Available only for Enterprise Plan customers that purchased the Logs Integration SKU. Numeric identifier of the account that purchased the logs integration SKU and which collects the logs. If not specified, operation will be performed on the account identified by the authentication parameters.",
+				Type:             schema.TypeString,
+				Optional:         true,
+				DiffSuppressFunc: deprecatedFlagDiffSuppress(),
 			},
 			"active": {
-				Description: "active or bypass.",
-				Type:        schema.TypeString,
-				Optional:    true,
-				Computed:    true,
+				Description:      "active or bypass.",
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				DiffSuppressFunc: deprecatedFlagDiffSuppress(),
 			},
 			"domain_validation": {
-				Description: "email or html or dns or cname.",
-				Type:        schema.TypeString,
-				Optional:    true,
+				Description:      "email or html or dns or cname.",
+				Type:             schema.TypeString,
+				Optional:         true,
+				DiffSuppressFunc: deprecatedFlagDiffSuppress(),
 			},
 			"approver": {
-				Description: "my.approver@email.com (some approver email address).",
-				Type:        schema.TypeString,
-				Optional:    true,
+				Description:      "my.approver@email.com (some approver email address).",
+				Type:             schema.TypeString,
+				Optional:         true,
+				DiffSuppressFunc: deprecatedFlagDiffSuppress(),
 			},
 			"ignore_ssl": {
-				Description: "true or empty string.",
-				Type:        schema.TypeString,
-				Optional:    true,
+				Description:      "true or empty string.",
+				Type:             schema.TypeString,
+				Optional:         true,
+				DiffSuppressFunc: deprecatedFlagDiffSuppress(),
 			},
 			"acceleration_level": {
-				Description: "none | standard | aggressive.",
-				Type:        schema.TypeString,
-				Optional:    true,
-				Computed:    true,
+				Description:      "none | standard | aggressive.",
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				DiffSuppressFunc: deprecatedFlagDiffSuppress(),
 			},
 			"seal_location": {
-				Description: "api.seal_location.bottom_left | api.seal_location.none | api.seal_location.right_bottom | api.seal_location.right | api.seal_location.left | api.seal_location.bottom_right | api.seal_location.bottom.",
-				Type:        schema.TypeString,
-				Optional:    true,
-				Computed:    true,
+				Description:      "api.seal_location.bottom_left | api.seal_location.none | api.seal_location.right_bottom | api.seal_location.right | api.seal_location.left | api.seal_location.bottom_right | api.seal_location.bottom.",
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				DiffSuppressFunc: deprecatedFlagDiffSuppress(),
 			},
 			"restricted_cname_reuse": {
-				Description: "Use this option to allow Imperva to detect and add domains that are using the Imperva-provided CNAME (not recommended). One of: true | false",
-				Type:        schema.TypeString,
-				Optional:    true,
-				Computed:    true,
+				Description:      "Use this option to allow Imperva to detect and add domains that are using the Imperva-provided CNAME (not recommended). One of: true | false",
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				DiffSuppressFunc: deprecatedFlagDiffSuppress(),
 			},
 			"domain_redirect_to_full": {
-				Description: "true or empty string.",
-				Type:        schema.TypeString,
-				Optional:    true,
+				Description:      "true or empty string.",
+				Type:             schema.TypeString,
+				Optional:         true,
+				DiffSuppressFunc: deprecatedFlagDiffSuppress(),
 			},
 			"remove_ssl": {
-				Description: "true or empty string.",
-				Type:        schema.TypeString,
-				Optional:    true,
+				Description:      "true or empty string.",
+				Type:             schema.TypeString,
+				Optional:         true,
+				DiffSuppressFunc: deprecatedFlagDiffSuppress(),
 			},
 			"data_storage_region": {
-				Description: "The data region to use. Options are `APAC`, `AU`, `EU`, and `US`.",
-				Type:        schema.TypeString,
-				Computed:    true,
-				Optional:    true,
+				Description:      "The data region to use. Options are `APAC`, `AU`, `EU`, and `US`.",
+				Type:             schema.TypeString,
+				Computed:         true,
+				Optional:         true,
+				DiffSuppressFunc: deprecatedFlagDiffSuppress(),
 			},
 			"hashing_enabled": {
-				Description: "Specify if hashing (masking setting) should be enabled.",
-				Type:        schema.TypeBool,
-				Computed:    true,
-				Optional:    true,
+				Description:      "Specify if hashing (masking setting) should be enabled.",
+				Type:             schema.TypeBool,
+				Computed:         true,
+				Optional:         true,
+				DiffSuppressFunc: deprecatedFlagDiffSuppress(),
 			},
 			"hash_salt": {
 				Description: "Specify the hash salt (masking setting), required if hashing is enabled. Maximum length of 64 characters.",
@@ -159,97 +186,113 @@ func resourceSite() *schema.Resource {
 					}
 					return
 				},
+				DiffSuppressFunc: deprecatedFlagDiffSuppress(),
 			},
 			"log_level": {
-				Description: "The log level. Options are `full`, `security`, and `none`.",
-				Type:        schema.TypeString,
-				Computed:    true,
-				Optional:    true,
+				Description:      "The log level. Options are `full`, `security`, and `none`.",
+				Type:             schema.TypeString,
+				Computed:         true,
+				Optional:         true,
+				DiffSuppressFunc: deprecatedFlagDiffSuppress(),
 			},
 			"perf_client_comply_no_cache": {
-				Description: "Comply with No-Cache and Max-Age directives in client requests. By default, these cache directives are ignored. Resources are dynamically profiled and re-configured to optimize performance.",
-				Type:        schema.TypeBool,
-				Computed:    true,
-				Optional:    true,
+				Description:      "Comply with No-Cache and Max-Age directives in client requests. By default, these cache directives are ignored. Resources are dynamically profiled and re-configured to optimize performance.",
+				Type:             schema.TypeBool,
+				Computed:         true,
+				Optional:         true,
+				DiffSuppressFunc: deprecatedFlagDiffSuppress(),
 			},
 			"perf_client_enable_client_side_caching": {
-				Description: "Cache content on client browsers or applications. When not enabled, content is cached only on the Imperva proxies.",
-				Type:        schema.TypeBool,
-				Computed:    true,
-				Optional:    true,
+				Description:      "Cache content on client browsers or applications. When not enabled, content is cached only on the Imperva proxies.",
+				Type:             schema.TypeBool,
+				Computed:         true,
+				Optional:         true,
+				DiffSuppressFunc: deprecatedFlagDiffSuppress(),
 			},
 			"perf_client_send_age_header": {
-				Description: "Send Cache-Control: max-age and Age headers.",
-				Type:        schema.TypeBool,
-				Computed:    true,
-				Optional:    true,
+				Description:      "Send Cache-Control: max-age and Age headers.",
+				Type:             schema.TypeBool,
+				Computed:         true,
+				Optional:         true,
+				DiffSuppressFunc: deprecatedFlagDiffSuppress(),
 			},
 			"perf_key_comply_vary": {
-				Description: "Comply with Vary. Cache resources in accordance with the Vary response header.",
-				Type:        schema.TypeBool,
-				Computed:    true,
-				Optional:    true,
+				Description:      "Comply with Vary. Cache resources in accordance with the Vary response header.",
+				Type:             schema.TypeBool,
+				Computed:         true,
+				Optional:         true,
+				DiffSuppressFunc: deprecatedFlagDiffSuppress(),
 			},
 			"perf_key_unite_naked_full_cache": {
-				Description: "Use the Same Cache for Full and Naked Domains. For example, use the same cached resource for www.example.com/a and example.com/a.",
-				Type:        schema.TypeBool,
-				Computed:    true,
-				Optional:    true,
+				Description:      "Use the Same Cache for Full and Naked Domains. For example, use the same cached resource for www.example.com/a and example.com/a.",
+				Type:             schema.TypeBool,
+				Computed:         true,
+				Optional:         true,
+				DiffSuppressFunc: deprecatedFlagDiffSuppress(),
 			},
 			"perf_mode_https": {
-				Description: "The resources that are cached over HTTPS, the general level applies. Options are `disabled`, `dont_include_html`, `include_html`, and `include_all_resources`.",
-				Type:        schema.TypeString,
-				Computed:    true,
-				Optional:    true,
+				Description:      "The resources that are cached over HTTPS, the general level applies. Options are `disabled`, `dont_include_html`, `include_html`, and `include_all_resources`.",
+				Type:             schema.TypeString,
+				Computed:         true,
+				Optional:         true,
+				DiffSuppressFunc: deprecatedFlagDiffSuppress(),
 			},
 			"perf_mode_level": {
-				Description: "Caching level. Options are `disable`, `standard`, `smart`, and `all_resources`.",
-				Type:        schema.TypeString,
-				Computed:    true,
-				Optional:    true,
+				Description:      "Caching level. Options are `disable`, `standard`, `smart`, and `all_resources`.",
+				Type:             schema.TypeString,
+				Computed:         true,
+				Optional:         true,
+				DiffSuppressFunc: deprecatedFlagDiffSuppress(),
 			},
 			"perf_mode_time": {
-				Description: "The time, in seconds, that you set for this option determines how often the cache is refreshed. Relevant for the `include_html` and `include_all_resources` levels only.",
-				Type:        schema.TypeInt,
-				Computed:    true,
-				Optional:    true,
+				Description:      "The time, in seconds, that you set for this option determines how often the cache is refreshed. Relevant for the `include_html` and `include_all_resources` levels only.",
+				Type:             schema.TypeInt,
+				Computed:         true,
+				Optional:         true,
+				DiffSuppressFunc: deprecatedFlagDiffSuppress(),
 			},
 			"perf_response_cache_300x": {
-				Description: "When this option is checked Imperva will cache 301, 302, 303, 307, and 308 redirect response headers containing the target URI.",
-				Type:        schema.TypeBool,
-				Computed:    true,
-				Optional:    true,
+				Description:      "When this option is checked Imperva will cache 301, 302, 303, 307, and 308 redirect response headers containing the target URI.",
+				Type:             schema.TypeBool,
+				Computed:         true,
+				Optional:         true,
+				DiffSuppressFunc: deprecatedFlagDiffSuppress(),
 			},
 			"perf_response_cache_404_enabled": {
-				Description: "Whether or not to cache 404 responses.",
-				Type:        schema.TypeBool,
-				Computed:    true,
-				Optional:    true,
+				Description:      "Whether or not to cache 404 responses.",
+				Type:             schema.TypeBool,
+				Computed:         true,
+				Optional:         true,
+				DiffSuppressFunc: deprecatedFlagDiffSuppress(),
 			},
 			"perf_response_cache_404_time": {
-				Description:  "The time in seconds to cache 404 responses.",
-				Type:         schema.TypeInt,
-				Computed:     true,
-				Optional:     true,
-				ValidateFunc: validation.IntDivisibleBy(60),
+				Description:      "The time in seconds to cache 404 responses.",
+				Type:             schema.TypeInt,
+				Computed:         true,
+				Optional:         true,
+				ValidateFunc:     validation.IntDivisibleBy(60),
+				DiffSuppressFunc: deprecatedFlagDiffSuppress(),
 			},
 			"perf_response_cache_empty_responses": {
-				Description: "Cache responses that don’t have a message body.",
-				Type:        schema.TypeBool,
-				Computed:    true,
-				Optional:    true,
+				Description:      "Cache responses that don’t have a message body.",
+				Type:             schema.TypeBool,
+				Computed:         true,
+				Optional:         true,
+				DiffSuppressFunc: deprecatedFlagDiffSuppress(),
 			},
 			"perf_response_cache_http_10_responses": {
-				Description: "Cache HTTP 1.0 type responses that don’t include the Content-Length header or chunking.",
-				Type:        schema.TypeBool,
-				Computed:    true,
-				Optional:    true,
+				Description:      "Cache HTTP 1.0 type responses that don’t include the Content-Length header or chunking.",
+				Type:             schema.TypeBool,
+				Computed:         true,
+				Optional:         true,
+				DiffSuppressFunc: deprecatedFlagDiffSuppress(),
 			},
 			"perf_response_cache_response_header_mode": {
-				Description: "The working mode for caching response headers. Options are `all`, `custom` and `disabled`.",
-				Type:        schema.TypeString,
-				Computed:    true,
-				Optional:    true,
+				Description:      "The working mode for caching response headers. Options are `all`, `custom` and `disabled`.",
+				Type:             schema.TypeString,
+				Computed:         true,
+				Optional:         true,
+				DiffSuppressFunc: deprecatedFlagDiffSuppress(),
 			},
 			"perf_response_cache_response_headers": {
 				Description: "An array of strings representing the response headers to be cached when working in `custom` mode. If empty, no response headers are cached.",
@@ -259,55 +302,63 @@ func resourceSite() *schema.Resource {
 				},
 				Computed:         true,
 				Optional:         true,
-				DiffSuppressFunc: suppressEquivalentStringDiffs,
+				DiffSuppressFunc: suppressEquivalentStringDiffsPlusDeprecated(),
 			},
 			"perf_response_cache_shield": {
-				Description: "Adds an intermediate cache between other Imperva PoPs and your origin servers to protect your servers from redundant requests.",
-				Type:        schema.TypeBool,
-				Computed:    true,
-				Optional:    true,
+				Description:      "Adds an intermediate cache between other Imperva PoPs and your origin servers to protect your servers from redundant requests.",
+				Type:             schema.TypeBool,
+				Computed:         true,
+				Optional:         true,
+				DiffSuppressFunc: deprecatedFlagDiffSuppress(),
 			},
 			"perf_response_stale_content_mode": {
-				Description: "The working mode for serving stale content. Options are `disabled`, `adaptive`, and `custom`.",
-				Type:        schema.TypeString,
-				Computed:    true,
-				Optional:    true,
+				Description:      "The working mode for serving stale content. Options are `disabled`, `adaptive`, and `custom`.",
+				Type:             schema.TypeString,
+				Computed:         true,
+				Optional:         true,
+				DiffSuppressFunc: deprecatedFlagDiffSuppress(),
 			},
 			"perf_response_stale_content_time": {
-				Description: "The time, in seconds, to serve stale content for when working in `custom` work mode.",
-				Type:        schema.TypeInt,
-				Computed:    true,
-				Optional:    true,
+				Description:      "The time, in seconds, to serve stale content for when working in `custom` work mode.",
+				Type:             schema.TypeInt,
+				Computed:         true,
+				Optional:         true,
+				DiffSuppressFunc: deprecatedFlagDiffSuppress(),
 			},
 			"perf_response_tag_response_header": {
-				Description: "Tag the response according to the value of this header. Specify which origin response header contains the cache tags in your resources.",
-				Type:        schema.TypeString,
-				Computed:    true,
-				Optional:    true,
+				Description:      "Tag the response according to the value of this header. Specify which origin response header contains the cache tags in your resources.",
+				Type:             schema.TypeString,
+				Computed:         true,
+				Optional:         true,
+				DiffSuppressFunc: deprecatedFlagDiffSuppress(),
 			},
 			"perf_ttl_prefer_last_modified": {
-				Description: "Prefer 'Last Modified' over eTag. When this option is checked, Imperva prefers using Last Modified values (if available) over eTag values (recommended on multi-server setups).",
-				Type:        schema.TypeBool,
-				Computed:    true,
-				Optional:    true,
+				Description:      "Prefer 'Last Modified' over eTag. When this option is checked, Imperva prefers using Last Modified values (if available) over eTag values (recommended on multi-server setups).",
+				Type:             schema.TypeBool,
+				Computed:         true,
+				Optional:         true,
+				DiffSuppressFunc: deprecatedFlagDiffSuppress(),
 			},
 			"perf_ttl_use_shortest_caching": {
-				Description: "Use shortest caching duration in case of conflicts. By default, the longest duration is used in case of conflict between caching rules or modes. When this option is checked, Imperva uses the shortest duration in case of conflict.",
-				Type:        schema.TypeBool,
-				Computed:    true,
-				Optional:    true,
+				Description:      "Use shortest caching duration in case of conflicts. By default, the longest duration is used in case of conflict between caching rules or modes. When this option is checked, Imperva uses the shortest duration in case of conflict.",
+				Type:             schema.TypeBool,
+				Computed:         true,
+				Optional:         true,
+				DiffSuppressFunc: deprecatedFlagDiffSuppress(),
 			},
 			"naked_domain_san": {
-				Description: "Use 'true' to add the naked domain SAN to a www site’s SSL certificate. Default value: true",
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     true,
+				Description:      "Use 'true' to add the naked domain SAN to a www site’s SSL certificate. Default value: true",
+				Type:             schema.TypeBool,
+				Optional:         true,
+				Default:          true,
+				DiffSuppressFunc: deprecatedFlagDiffSuppress(),
 			},
 			"wildcard_san": {
-				Description: "Use 'true' to add the wildcard SAN or 'false' to add the full domain SAN to the site’s SSL certificate. Default value: true",
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     true,
+				Description:      "Use 'true' to add the wildcard SAN or 'false' to add the full domain SAN to the site’s SSL certificate. Default value: true",
+				Type:             schema.TypeBool,
+				Optional:         true,
+				Default:          true,
+				DiffSuppressFunc: deprecatedFlagDiffSuppress(),
 			},
 			// Computed Attributes
 			"site_creation_date": {
@@ -356,13 +407,38 @@ func resourceSite() *schema.Resource {
 			},
 		},
 
+		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+			if d.HasChange("deprecated") {
+				oldVal, newVal := d.GetChange("deprecated")
+				if oldVal.(bool) && !newVal.(bool) {
+					return fmt.Errorf("deprecated flag cannot be changed from true to false")
+				}
+			}
+			return nil
+		},
+
 		Timeouts: &schema.ResourceTimeout{
 			Delete: schema.DefaultTimeout(1 * time.Minute),
 		},
 	}
 }
 
+func deprecatedFlagDiffSuppress() func(k string, old string, new string, d *schema.ResourceData) bool {
+	return func(k, old, new string, d *schema.ResourceData) bool {
+		return d.Get("deprecated").(bool)
+	}
+}
+
+func suppressEquivalentStringDiffsPlusDeprecated() func(k string, old string, new string, d *schema.ResourceData) bool {
+	return func(k, old, new string, d *schema.ResourceData) bool {
+		return suppressEquivalentStringDiffs(k, old, new, d) || d.Get("deprecated").(bool)
+	}
+}
+
 func resourceSiteCreate(d *schema.ResourceData, m interface{}) error {
+	if d.Get("deprecated").(bool) {
+		return fmt.Errorf("cannot create deprecated resource")
+	}
 	client := m.(*Client)
 	domain := d.Get("domain").(string)
 
@@ -423,6 +499,10 @@ func resourceSiteCreate(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceSiteRead(d *schema.ResourceData, m interface{}) error {
+	if d.Get("deprecated").(bool) {
+		fmt.Printf("[WARN] Resource incapsule_site for domain %s is deprecated. Any future changes will be ignored.\n", d.Get("domain").(string))
+		return nil
+	}
 	client := m.(*Client)
 
 	domain := d.Get("domain").(string)
@@ -575,6 +655,10 @@ func resourceSiteRead(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceSiteUpdate(d *schema.ResourceData, m interface{}) error {
+	if d.Get("deprecated").(bool) {
+		return nil
+	}
+
 	client := m.(*Client)
 
 	err := updateAdditionalSiteProperties(update_retries, client, d)
@@ -607,6 +691,11 @@ func resourceSiteUpdate(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceSiteDelete(d *schema.ResourceData, m interface{}) error {
+	if d.Get("deprecated").(bool) {
+		d.SetId("")
+		return nil
+	}
+
 	client := m.(*Client)
 	domain := d.Get("domain").(string)
 	siteID, _ := strconv.Atoi(d.Id())

--- a/incapsula/resource_site_test.go
+++ b/incapsula/resource_site_test.go
@@ -1,9 +1,11 @@
 package incapsula
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"testing"
@@ -52,6 +54,175 @@ func TestAccIncapsulaSite_Basic(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"site_ip", "domain_validation"},
+			},
+		},
+	})
+}
+
+func TestAccIncapsulaSite_DeprecationFlag_siteNotCreated(t *testing.T) { //done
+	domainName = GenerateTestDomain(t)
+	resource_name := "testacc-terraform-site_deprecated_test"
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCheckIncapsulaSiteConfigDeprecated(resource_name, domainName, true),
+				ExpectError: regexp.MustCompile("cannot create deprecated resource"),
+			},
+		},
+	})
+}
+
+func TestAccIncapsulaSite_ChangeDeprecatedFlag(t *testing.T) { //done
+	domainName = GenerateTestDomain(t)
+	resource_name := "testacc-terraform-site_deprecated_test"
+	full_resource_name := "incapsula_site." + resource_name
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckIncapsulaSiteNotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIncapsulaSiteConfigDeprecated(resource_name, domainName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckIncapsulaSiteExists(full_resource_name),
+					resource.TestCheckResourceAttr(full_resource_name, "domain", domainName),
+				),
+			},
+			{
+				Config: testAccCheckIncapsulaSiteConfigDeprecated(resource_name, domainName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckIncapsulaSiteExists(full_resource_name),
+					resource.TestCheckResourceAttr(full_resource_name, "domain", domainName),
+				),
+			},
+			{
+				Config: testAccCheckIncapsulaSiteConfigDeprecated(resource_name, domainName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckIncapsulaSiteExists(full_resource_name),
+					resource.TestCheckResourceAttr(full_resource_name, "domain", domainName),
+				),
+				ExpectError: regexp.MustCompile("deprecated flag cannot be changed from true to false"),
+			},
+		},
+	})
+}
+
+func TestAccIncapsulaSite_DeprecationFlagChangeAttributes(t *testing.T) {
+	domainName = GenerateTestDomain(t)
+	resource_name := "testacc-terraform-site_deprecated_test"
+	full_resource_name := "incapsula_site." + resource_name
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckIncapsulaSiteNotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIncapsulaSiteConfigAllParams(resource_name, domainName, false, "aggressive", "active",
+					true, "dns", false, false,
+					"ref123", "api.seal_location.bottom_right", true, false, false,
+					"EU", true, "salt123", "full",
+					false, false, false, true,
+					false, "dont_include_html", "smart", 7200,
+					false, true, 1200,
+					false, false,
+					"custom", []string{"Content-Type"},
+					false, "custom", 600,
+					"X-Cache-Tag-1", false, false),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckIncapsulaSiteExists(full_resource_name),
+					resource.TestCheckResourceAttr(full_resource_name, "domain", domainName),
+					resource.TestCheckResourceAttr(full_resource_name, "acceleration_level", "aggressive"),
+					resource.TestCheckResourceAttr(full_resource_name, "active", "active"),
+					resource.TestCheckResourceAttr(full_resource_name, "domain_redirect_to_full", "true"),
+					resource.TestCheckResourceAttr(full_resource_name, "domain_validation", "dns"),
+					resource.TestCheckResourceAttr(full_resource_name, "ignore_ssl", "false"),
+					resource.TestCheckResourceAttr(full_resource_name, "remove_ssl", "false"),
+					resource.TestCheckResourceAttr(full_resource_name, "ref_id", "ref123"),
+					resource.TestCheckResourceAttr(full_resource_name, "seal_location", "api.seal_location.bottom_right"),
+					resource.TestCheckResourceAttr(full_resource_name, "restricted_cname_reuse", "true"),
+					resource.TestCheckResourceAttr(full_resource_name, "naked_domain_san", "false"),
+					resource.TestCheckResourceAttr(full_resource_name, "wildcard_san", "false"),
+					resource.TestCheckResourceAttr(full_resource_name, "data_storage_region", "EU"),
+					resource.TestCheckResourceAttr(full_resource_name, "hashing_enabled", "true"),
+					resource.TestCheckResourceAttr(full_resource_name, "hash_salt", "salt123"),
+					resource.TestCheckResourceAttr(full_resource_name, "log_level", "full"),
+					resource.TestCheckResourceAttr(full_resource_name, "perf_client_comply_no_cache", "false"),
+					resource.TestCheckResourceAttr(full_resource_name, "perf_client_enable_client_side_caching", "false"),
+					resource.TestCheckResourceAttr(full_resource_name, "perf_client_send_age_header", "false"),
+					resource.TestCheckResourceAttr(full_resource_name, "perf_key_comply_vary", "true"),
+					resource.TestCheckResourceAttr(full_resource_name, "perf_key_unite_naked_full_cache", "false"),
+					resource.TestCheckResourceAttr(full_resource_name, "perf_mode_https", "dont_include_html"),
+					resource.TestCheckResourceAttr(full_resource_name, "perf_mode_level", "smart"),
+					resource.TestCheckResourceAttr(full_resource_name, "perf_mode_time", "7200"),
+					resource.TestCheckResourceAttr(full_resource_name, "perf_response_cache_300x", "false"),
+					resource.TestCheckResourceAttr(full_resource_name, "perf_response_cache_404_enabled", "true"),
+					resource.TestCheckResourceAttr(full_resource_name, "perf_response_cache_404_time", "1200"),
+					resource.TestCheckResourceAttr(full_resource_name, "perf_response_cache_empty_responses", "false"),
+					resource.TestCheckResourceAttr(full_resource_name, "perf_response_cache_http_10_responses", "false"),
+					resource.TestCheckResourceAttr(full_resource_name, "perf_response_cache_response_header_mode", "custom"),
+					resource.TestCheckResourceAttr(full_resource_name, "perf_response_cache_response_headers.0", "Content-Type"),
+					resource.TestCheckResourceAttr(full_resource_name, "perf_response_cache_shield", "false"),
+					resource.TestCheckResourceAttr(full_resource_name, "perf_response_stale_content_mode", "custom"),
+					resource.TestCheckResourceAttr(full_resource_name, "perf_response_stale_content_time", "600"),
+					resource.TestCheckResourceAttr(full_resource_name, "perf_response_tag_response_header", "X-Cache-Tag-1"),
+					resource.TestCheckResourceAttr(full_resource_name, "perf_ttl_prefer_last_modified", "false"),
+					resource.TestCheckResourceAttr(full_resource_name, "perf_ttl_use_shortest_caching", "false"),
+				),
+			},
+			{
+				Config: testAccCheckIncapsulaSiteConfigAllParams(resource_name, domainName, true, "none", "bypass",
+					false, "email", true, true,
+					"ref456", "api.seal_location.bottom_left", false, true, true,
+					"APAC", false, "salt456", "none",
+					true, true, true, false,
+					true, "disabled", "disable", 3600,
+					true, true, 600,
+					true, true,
+					"all", []string{"Authorization"},
+					true, "disabled", 300,
+					"X-Cache-Tag-2", true, true),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckIncapsulaSiteExists(full_resource_name),
+					resource.TestCheckResourceAttr(full_resource_name, "domain", domainName),
+					resource.TestCheckResourceAttr(full_resource_name, "acceleration_level", "aggressive"),
+					resource.TestCheckResourceAttr(full_resource_name, "active", "active"),
+					resource.TestCheckResourceAttr(full_resource_name, "domain_redirect_to_full", "true"),
+					resource.TestCheckResourceAttr(full_resource_name, "domain_validation", "dns"),
+					resource.TestCheckResourceAttr(full_resource_name, "ignore_ssl", "false"),
+					resource.TestCheckResourceAttr(full_resource_name, "remove_ssl", "false"),
+					resource.TestCheckResourceAttr(full_resource_name, "ref_id", "ref123"),
+					resource.TestCheckResourceAttr(full_resource_name, "seal_location", "api.seal_location.bottom_right"),
+					resource.TestCheckResourceAttr(full_resource_name, "restricted_cname_reuse", "true"),
+					resource.TestCheckResourceAttr(full_resource_name, "naked_domain_san", "false"),
+					resource.TestCheckResourceAttr(full_resource_name, "wildcard_san", "false"),
+					resource.TestCheckResourceAttr(full_resource_name, "data_storage_region", "EU"),
+					resource.TestCheckResourceAttr(full_resource_name, "hashing_enabled", "true"),
+					resource.TestCheckResourceAttr(full_resource_name, "hash_salt", "salt123"),
+					resource.TestCheckResourceAttr(full_resource_name, "log_level", "full"),
+					resource.TestCheckResourceAttr(full_resource_name, "perf_client_comply_no_cache", "false"),
+					resource.TestCheckResourceAttr(full_resource_name, "perf_client_enable_client_side_caching", "false"),
+					resource.TestCheckResourceAttr(full_resource_name, "perf_client_send_age_header", "false"),
+					resource.TestCheckResourceAttr(full_resource_name, "perf_key_comply_vary", "true"),
+					resource.TestCheckResourceAttr(full_resource_name, "perf_key_unite_naked_full_cache", "false"),
+					resource.TestCheckResourceAttr(full_resource_name, "perf_mode_https", "dont_include_html"),
+					resource.TestCheckResourceAttr(full_resource_name, "perf_mode_level", "smart"),
+					resource.TestCheckResourceAttr(full_resource_name, "perf_mode_time", "7200"),
+					resource.TestCheckResourceAttr(full_resource_name, "perf_response_cache_300x", "false"),
+					resource.TestCheckResourceAttr(full_resource_name, "perf_response_cache_404_enabled", "true"),
+					resource.TestCheckResourceAttr(full_resource_name, "perf_response_cache_404_time", "1200"),
+					resource.TestCheckResourceAttr(full_resource_name, "perf_response_cache_empty_responses", "false"),
+					resource.TestCheckResourceAttr(full_resource_name, "perf_response_cache_http_10_responses", "false"),
+					resource.TestCheckResourceAttr(full_resource_name, "perf_response_cache_response_header_mode", "custom"),
+					resource.TestCheckResourceAttr(full_resource_name, "perf_response_cache_response_headers.0", "Content-Type"),
+					resource.TestCheckResourceAttr(full_resource_name, "perf_response_cache_shield", "false"),
+					resource.TestCheckResourceAttr(full_resource_name, "perf_response_stale_content_mode", "custom"),
+					resource.TestCheckResourceAttr(full_resource_name, "perf_response_stale_content_time", "600"),
+					resource.TestCheckResourceAttr(full_resource_name, "perf_response_tag_response_header", "X-Cache-Tag-1"),
+					resource.TestCheckResourceAttr(full_resource_name, "perf_ttl_prefer_last_modified", "false"),
+					resource.TestCheckResourceAttr(full_resource_name, "perf_ttl_use_shortest_caching", "false"),
+				),
 			},
 		},
 	})
@@ -129,4 +300,117 @@ func testAccCheckIncapsulaSiteConfigBasic(domain string) string {
 		}`,
 		domain,
 	)
+}
+
+func testAccCheckIncapsulaSiteConfigDeprecated(resource_name string, domain string, deprecated bool) string {
+	return fmt.Sprintf(`
+		resource "incapsula_site" "%s" {
+			domain = "%s"
+			deprecated = %t
+		}`,
+		resource_name,
+		domain,
+		deprecated,
+	)
+}
+
+func testAccCheckIncapsulaSiteConfigAllParams(resource_name string, domain string, deprecated bool, accelerationLevel string, active string,
+	domainRedirectToFull bool, domainValidation string, ignoreSsl bool, removeSsl bool, refId string, sealLocation string,
+	restrictedCnameReuse bool, nakedDomainSan bool, wildcardSan bool, dataStorageRegion string, hashingEnabled bool,
+	hashSalt string, logLevel string, perfClientComplyNoCache bool, perfClientEnableClientSideCaching bool,
+	perfClientSendAgeHeader bool, perfKeyComplyVary bool, perfKeyUniteNakedFullCache bool, perfModeHttps string,
+	perfModeLevel string, perfModeTime int, perfResponseCache300x bool, perfResponseCache404Enabled bool,
+	perfResponseCache404Time int, perfResponseCacheEmptyResponses bool, perfResponseCacheHttp10Responses bool,
+	perfResponseCacheResponseHeaderMode string, perfResponseCacheResponseHeaders []string, perfResponseCacheShield bool,
+	perfResponseStaleContentMode string, perfResponseStaleContentTime int, perfResponseTagResponseHeader string,
+	perfTtlPreferLastModified bool, perfTtlUseShortestCaching bool,
+) string {
+	return fmt.Sprintf(`
+resource "incapsula_site"         "%s" {
+  domain                          = "%s"
+  deprecated                      = %t
+  acceleration_level              = "%s"
+  active                          = "%s"
+  domain_redirect_to_full         = %t
+  domain_validation               = "%s"
+  ignore_ssl                      = %t
+  remove_ssl                      = %t
+  ref_id                          = "%s"
+  seal_location                   = "%s"
+  restricted_cname_reuse          = %t
+  naked_domain_san                = %t
+  wildcard_san                    = %t
+  data_storage_region             = "%s"
+  hashing_enabled                 = %t
+  hash_salt                       = "%s"
+  log_level                       = "%s"
+  perf_client_comply_no_cache     = %t
+  perf_client_enable_client_side_caching = %t
+  perf_client_send_age_header     = %t
+  perf_key_comply_vary            = %t
+  perf_key_unite_naked_full_cache = %t
+  perf_mode_https                 = "%s"
+  perf_mode_level                 = "%s"
+  perf_mode_time                  = %d
+  perf_response_cache_300x        = %t
+  perf_response_cache_404_enabled = %t
+  perf_response_cache_404_time    = %d
+  perf_response_cache_empty_responses = %t
+  perf_response_cache_http_10_responses = %t
+  perf_response_cache_response_header_mode = "%s"
+  perf_response_cache_response_headers = ["%s"]
+  perf_response_cache_shield      = %t
+  perf_response_stale_content_mode = "%s"
+  perf_response_stale_content_time = %d
+  perf_response_tag_response_header = "%s"
+  perf_ttl_prefer_last_modified   = %t
+  perf_ttl_use_shortest_caching   = %t
+}`,
+		resource_name, domain, deprecated, accelerationLevel, active, domainRedirectToFull, domainValidation, ignoreSsl, removeSsl, refId,
+		sealLocation, restrictedCnameReuse, nakedDomainSan, wildcardSan, dataStorageRegion, hashingEnabled, hashSalt, logLevel,
+		perfClientComplyNoCache, perfClientEnableClientSideCaching, perfClientSendAgeHeader, perfKeyComplyVary, perfKeyUniteNakedFullCache, perfModeHttps,
+		perfModeLevel, perfModeTime, perfResponseCache300x, perfResponseCache404Enabled, perfResponseCache404Time, perfResponseCacheEmptyResponses,
+		perfResponseCacheHttp10Responses, perfResponseCacheResponseHeaderMode, strings.Join(perfResponseCacheResponseHeaders, "\", \""),
+		perfResponseCacheShield, perfResponseStaleContentMode, perfResponseStaleContentTime, perfResponseTagResponseHeader, perfTtlPreferLastModified,
+		perfTtlUseShortestCaching,
+	)
+}
+
+func testCheckIncapsulaSiteNotDestroy(state *terraform.State) error {
+	client := testAccProvider.Meta().(*Client)
+
+	for _, res := range state.RootModule().Resources {
+		if res.Type != "incapsula_site" {
+			continue
+		}
+
+		siteIDStr := res.Primary.ID
+		if siteIDStr == "" {
+			return fmt.Errorf("Incapsula site ID does not exist")
+		}
+
+		siteID, err := strconv.Atoi(siteIDStr)
+		if err != nil {
+			return fmt.Errorf("Site ID conversion error for %s: %s", siteIDStr, err)
+		}
+
+		domain := res.Primary.Attributes["domain"]
+		siteStatusResponse, err := client.SiteStatus(domain, siteID)
+
+		if err != nil {
+			return fmt.Errorf("Site status error for %s: %s", siteIDStr, err)
+		}
+
+		if siteStatusResponse == nil || siteStatusResponse.SiteID != siteID {
+			response, _ := json.Marshal(siteStatusResponse)
+			return fmt.Errorf("Incapsula site status for domain: %s (site id: %d) was not retreived. response: %s", domain, siteID, response)
+		}
+		err = client.DeleteSite(domain, siteID) // clean the env after checking
+
+		if err != nil {
+			return fmt.Errorf("Error deleting site (%d) for domain %s: %s", siteID, domain, err)
+		}
+	}
+
+	return nil
 }

--- a/website/docs/r/site.html.markdown
+++ b/website/docs/r/site.html.markdown
@@ -57,7 +57,6 @@ The following arguments are supported:
 
 * `domain` - (Required) The fully qualified domain name of the site. For example: www.example.com, hello.example.com.
 * `account_id` - (Optional) The account to operate on. If not specified, operation will be performed on the account identified by the authentication parameters.
-* `deprecated`  - (Optional) Once set to true, this setting is irreversible. Use true to deprecate the resource, preventing any further changes from taking effect. Deleting the resource will not remove the site. Default: false.
 * `send_site_setup_emails` - (Optional) If this value is false, end users will not get emails about the add site process such as DNS instructions and SSL setup.
 * `site_ip` - (Optional) The web server IP/CNAME. This field should be specified when creating a site and the domain does not yet exist or the domain already points to Imperva Cloud. When specified, its value will be used for adding site only. After site is already created this field will be ignored. To modify site ip, please use resource incapsula_data_centers_configuration instead.
 * `force_ssl` - (Optional) Force SSL. This option is only available for sites with manually configured IP/CNAME and for specific accounts.


### PR DESCRIPTION
adding deprecated flag to incapsula_site resource. Once set to true, this setting is irreversible. Use true to deprecate the resource, preventing any further changes from taking effect. Deleting the resource will not remove the site.