### PR TITLE
Add SSL Validation Timeout Property

### DIFF
--- a/incapsula/data_source_ssl_instructions.go
+++ b/incapsula/data_source_ssl_instructions.go
@@ -18,7 +18,6 @@ func dataSourceSSLInstructions() *schema.Resource {
 		Description: "Provides data about SSL instructions",
 
 		Schema: map[string]*schema.Schema{
-			// Computed Attributes
 			"site_id": {
 				Description: "Numeric identifier of the site to operate on.",
 				Type:        schema.TypeString,
@@ -38,6 +37,7 @@ func dataSourceSSLInstructions() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 			},
+			// Computed Attributes
 			"instructions": {
 				Description: "A set of SSL instructions.",
 				Computed:    true,

--- a/incapsula/data_source_ssl_instructions.go
+++ b/incapsula/data_source_ssl_instructions.go
@@ -74,17 +74,17 @@ func dataSourceSSLInstructions() *schema.Resource {
 
 func dataSourceSSLInstructionsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*Client)
-	siteId := d.Get("site_id").(string)
-	atoi, _ := strconv.Atoi(siteId)
-	waitForInstructions(client, atoi)
-	sSLInstructionsResponse, err := client.GetSiteSSLInstructions(atoi)
+	siteIdStr := d.Get("site_id").(string)
+	siteId, _ := strconv.Atoi(siteIdStr)
+	waitForInstructions(client, siteId)
+	sSLInstructionsResponse, err := client.GetSiteSSLInstructions(siteId)
 	if err != nil {
 		return diag.Errorf("Error request site SSL instructions: %v", err)
 	}
 	if sSLInstructionsResponse.Data != nil && len(sSLInstructionsResponse.Data) > 0 {
 		populateInstructionsFromDTO(d, sSLInstructionsResponse.Data)
 	}
-	d.SetId(siteId)
+	d.SetId(siteIdStr)
 	return nil
 }
 


### PR DESCRIPTION
Hi there!

Currently, the `incapsula_ssl_instructions` data source waits for validation to be completed by looping up to 20 times in 10-second increments.

Delaying until the process is complete is, unfortunately, the only way to deal with nondeterminism from other layers of the stack, such as the TLS CA certificate creation process. I completely understand!

However, rather than keep the value `20` statically hardcoded internally, this PR adds a new property called `validation_timeout` to the `incapsula_ssl_instructions` data source which allows the user to specify a timeout length in seconds.

This way, the user can specify how long the validation step should wait until it is considered to have failed.

Haven't opened many of these and I don't usually write Golang, so I'm very open to feedback!

Thanks!