### PR TITLE
Add SSL Validation Timeout Property

### DIFF
--- a/incapsula/data_source_ssl_instructions.go
+++ b/incapsula/data_source_ssl_instructions.go
@@ -82,8 +82,7 @@ func dataSourceSSLInstructionsRead(ctx context.Context, d *schema.ResourceData, 
 	client := m.(*Client)
 	siteIdStr := d.Get("site_id").(string)
 	siteId, _ := strconv.Atoi(siteIdStr)
-	timeoutStr := d.Get("validation_timeout").(string)
-	timeout, _ := strconv.Atoi(timeoutStr)
+	timeout := d.Get("validation_timeout").(int)
 	waitForInstructions(client, siteId, timeout)
 	sSLInstructionsResponse, err := client.GetSiteSSLInstructions(siteId)
 	if err != nil {

--- a/incapsula/data_source_ssl_instructions.go
+++ b/incapsula/data_source_ssl_instructions.go
@@ -74,17 +74,17 @@ func dataSourceSSLInstructions() *schema.Resource {
 
 func dataSourceSSLInstructionsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*Client)
-	siteId := d.Get("site_id").(string)
-	atoi, _ := strconv.Atoi(siteId)
-	waitForInstructions(client, atoi)
-	sSLInstructionsResponse, err := client.GetSiteSSLInstructions(atoi)
+	siteIdStr := d.Get("site_id").(string)
+	siteId, _ := strconv.Atoi(siteIdStr)
+	waitForInstructions(client, siteId)
+	sSLInstructionsResponse, err := client.GetSiteSSLInstructions(siteId)
 	if err != nil {
 		return diag.Errorf("Error request site SSL instructions: %v", err)
 	}
 	if sSLInstructionsResponse.Data != nil && len(sSLInstructionsResponse.Data) > 0 {
 		populateInstructionsFromDTO(d, sSLInstructionsResponse.Data)
 	}
-	d.SetId(siteId)
+	d.SetId(siteIdStr)
 	return nil
 }
 

--- a/incapsula/data_source_ssl_instructions.go
+++ b/incapsula/data_source_ssl_instructions.go
@@ -18,7 +18,6 @@ func dataSourceSSLInstructions() *schema.Resource {
 		Description: "Provides data about SSL instructions",
 
 		Schema: map[string]*schema.Schema{
-			// Computed Attributes
 			"site_id": {
 				Description: "Numeric identifier of the site to operate on.",
 				Type:        schema.TypeString,
@@ -38,6 +37,13 @@ func dataSourceSSLInstructions() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 			},
+			"validation_timeout": {
+				Description: "Length of time in seconds to wait for SSL validation.",
+				Type:        schema.TypeInt,
+				Required:    false,
+				Default:     200,
+			},
+			// Computed Attributes
 			"instructions": {
 				Description: "A set of SSL instructions.",
 				Computed:    true,
@@ -76,7 +82,9 @@ func dataSourceSSLInstructionsRead(ctx context.Context, d *schema.ResourceData, 
 	client := m.(*Client)
 	siteIdStr := d.Get("site_id").(string)
 	siteId, _ := strconv.Atoi(siteIdStr)
-	waitForInstructions(client, siteId)
+	timeoutStr := d.Get("validation_timeout").(string)
+	timeout, _ := strconv.Atoi(timeoutStr)
+	waitForInstructions(client, siteId, timeout)
 	sSLInstructionsResponse, err := client.GetSiteSSLInstructions(siteId)
 	if err != nil {
 		return diag.Errorf("Error request site SSL instructions: %v", err)
@@ -88,20 +96,34 @@ func dataSourceSSLInstructionsRead(ctx context.Context, d *schema.ResourceData, 
 	return nil
 }
 
-func waitForInstructions(client *Client, siteId int) diag.Diagnostics {
+func getSslValidationStatus(client *Client, siteId int, dtoData []SiteDomainDetails) bool {
+	siteCertificateV3Response, _ := client.GetSiteCertificateRequestStatus(siteId, nil)
+	b := siteCertificateV3Response != nil && siteCertificateV3Response.Data != nil && len(siteCertificateV3Response.Data) > 0
+	b = b && siteCertificateV3Response.Data[0].CertificatesDetails != nil && validateSans(siteCertificateV3Response.Data[0], dtoData)
+	return b
+}
+
+func waitForInstructions(client *Client, siteId int, timeout int) diag.Diagnostics {
 	siteDomainDetailsDto, err := client.GetWebsiteDomains(strconv.Itoa(siteId))
 	if err != nil {
 		return diag.Errorf("Error getting site %d domains: %v", siteId, err)
 	}
 	if siteDomainDetailsDto.Data != nil && len(siteDomainDetailsDto.Data) > 0 {
-		for i := 0; i < 20; i++ {
-			siteCertificateV3Response, _ := client.GetSiteCertificateRequestStatus(siteId, nil)
-			b := siteCertificateV3Response != nil && siteCertificateV3Response.Data != nil && len(siteCertificateV3Response.Data) > 0
-			b = b && siteCertificateV3Response.Data[0].CertificatesDetails != nil && validateSans(siteCertificateV3Response.Data[0], siteDomainDetailsDto.Data)
-			if b {
+		// Base case
+		if getSslValidationStatus(client, siteId, siteDomainDetailsDto.Data) {
+			return nil
+		}
+		// Try with delay until timeout
+		limit := time.Duration(timeout) * time.Second
+		start := time.Now()
+		current := time.Now()
+		for current.Sub(start) <= limit {
+			time.Sleep(10 * time.Second)
+			current = time.Now()
+
+			if getSslValidationStatus(client, siteId, siteDomainDetailsDto.Data) {
 				return nil
 			}
-			time.Sleep(10 * time.Second)
 		}
 		panic("managed certificate was not created as expected")
 	}

--- a/incapsula/data_source_ssl_instructions.go
+++ b/incapsula/data_source_ssl_instructions.go
@@ -40,7 +40,7 @@ func dataSourceSSLInstructions() *schema.Resource {
 			"validation_timeout": {
 				Description: "Length of time in seconds to wait for SSL validation.",
 				Type:        schema.TypeInt,
-				Required:    false,
+				Optional:    true,
 				Default:     200,
 			},
 			// Computed Attributes


### PR DESCRIPTION
Hey all,

I previously submitted PR #558, but was a little too slow in addressing the feedback.
(Trying to work these OSS contribs into my team's sprints)

Previously, I had incorrectly unmarshaled a string as an int (contrary to the added schema) and incorrectly set `Required: false` instead of `Optional: true` in the data source schema contrary to the [Hashicorp's documented schema behaviors](https://developer.hashicorp.com/terraform/plugin/sdkv2/schemas/schema-behaviors).

This PR addresses that typo and oversight, respectively.

The result adds a new property called `validation_timeout` to the `ssl_instructions` data source that allows the user to specify a custom timeout for SSL validation, instead of relying on a hardcoded default. Delay is done in 10-second intervals until the limit is reached or passed.


Like mentioned on that other PR, Golang isn't my primary language so I'm very open to feedback if I've violated a style convention. I've made sure my submission passes format checking as done in the Makefile, though.


Please let me know what you think!

Thanks!

