### PR TITLE
bug fix - incapsula_custom_certificate resource update flow crash

### DIFF
--- a/incapsula/client_certificate.go
+++ b/incapsula/client_certificate.go
@@ -144,7 +144,7 @@ func (c *Client) EditCertificate(siteID, certificate, privateKey, passphrase, au
 	if passphrase != "" {
 		values.Set("passphrase", passphrase)
 	}
-	if passphrase != "" {
+	if authType != "" {
 		values.Set("auth_type", authType)
 	}
 


### PR DESCRIPTION
bug fix - incapsula_custom_certificate resource update flow was used to crash when provided certificate was ecc without passphrase