### PR TITLE
Fix incapsula_csp_site_domain inconsistency when Imperva normalizes referenceId server-side

### DIFF
--- a/incapsula/client_csp_site_domain.go
+++ b/incapsula/client_csp_site_domain.go
@@ -218,10 +218,9 @@ func (c *Client) deleteCSPDomainNotes(accountID, siteID int, domain string) erro
 	return nil
 }
 
-func (c *Client) getCSPPreApprovedDomain(accountID, siteID int, domain string) (*CSPPreApprovedDomain, error) {
-	log.Printf("[INFO] Getting CSP pre-approved domain %s from site ID: %d\n", domain, siteID)
+func (c *Client) getCSPPreApprovedDomainByRef(accountID, siteID int, domainRef string) (*CSPPreApprovedDomain, error) {
+	log.Printf("[INFO] Getting CSP pre-approved domain by ref %s from site ID: %d\n", domainRef, siteID)
 
-	domainRef := base64.RawURLEncoding.EncodeToString([]byte(domain))
 	var resp *http.Response
 	var err error
 	if accountID != 0 {
@@ -239,28 +238,29 @@ func (c *Client) getCSPPreApprovedDomain(accountID, siteID int, domain string) (
 		return nil, fmt.Errorf("Error from CSP API for when getting pre-approved domains list for site ID %d: %s\n", siteID, err)
 	}
 
-	// Read the body
 	defer resp.Body.Close()
 	responseBody, err := ioutil.ReadAll(resp.Body)
 
-	// Dump JSON
 	log.Printf("[DEBUG] CSP API Get Pre-Approved Domain Data JSON response: %s\n", string(responseBody))
 
-	// Check the response code
 	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("Error status code %d from CSP API when getting pre-approved domain %s for site %d: %s\n",
-			resp.StatusCode, domain, siteID, string(responseBody))
+		return nil, fmt.Errorf("Error status code %d from CSP API when getting pre-approved domain ref %s for site %d: %s\n",
+			resp.StatusCode, domainRef, siteID, string(responseBody))
 	}
 
-	// Parse the JSON
 	var preApprovedDomain CSPPreApprovedDomain
 	err = json.Unmarshal([]byte(responseBody), &preApprovedDomain)
 	if err != nil {
-		return nil, fmt.Errorf("Error parsing JSON response for pre-approved domain %s for site ID %d: %s\nresponse: %s\n",
-			domain, siteID, err, string(responseBody))
+		return nil, fmt.Errorf("Error parsing JSON response for pre-approved domain ref %s for site ID %d: %s\nresponse: %s\n",
+			domainRef, siteID, err, string(responseBody))
 	}
 
 	return &preApprovedDomain, nil
+}
+
+func (c *Client) getCSPPreApprovedDomain(accountID, siteID int, domain string) (*CSPPreApprovedDomain, error) {
+	domainRef := base64.RawURLEncoding.EncodeToString([]byte(domain))
+	return c.getCSPPreApprovedDomainByRef(accountID, siteID, domainRef)
 }
 
 func (c *Client) updateCSPPreApprovedDomain(accountID, siteID int, dom *CSPPreApprovedDomain) (*CSPPreApprovedDomain, error) {

--- a/incapsula/client_csp_site_domain_test.go
+++ b/incapsula/client_csp_site_domain_test.go
@@ -182,6 +182,37 @@ func TestCSPSiteDomainPreApprovedUpdateResponse(t *testing.T) {
 	}
 }
 
+// TestCSPSiteDomainPreApprovedUpdateResponse_wildcardReferenceId verifies that
+// the client captures the server-assigned referenceId from the POST response.
+// Real Imperva returns base64url("*.domain") when subdomains=true.
+func TestCSPSiteDomainPreApprovedUpdateResponse_wildcardReferenceId(t *testing.T) {
+	apiID := "foo"
+	apiKey := "bar"
+	siteID := 42
+	accountID := 55
+	wildcardRef := "Ki5leGFtcGxlLmNvbQ" // base64url("*.example.com")
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.WriteHeader(201)
+		rw.Write([]byte(`{"domain":"example.com","subdomains":true,"referenceId":"` + wildcardRef + `"}`))
+	}))
+	defer server.Close()
+
+	config := &Config{APIID: apiID, APIKey: apiKey, BaseURL: server.URL, BaseURLRev2: server.URL, BaseURLAPI: server.URL}
+	client := &Client{config: config, httpClient: &http.Client{}}
+
+	result, err := client.updateCSPPreApprovedDomain(accountID, siteID, &CSPPreApprovedDomain{
+		Domain:     "example.com",
+		Subdomains: true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if result.ReferenceID != wildcardRef {
+		t.Errorf("ReferenceID = %q, want %q", result.ReferenceID, wildcardRef)
+	}
+}
+
 func TestCSPSiteDomainNotesResponse(t *testing.T) {
 	apiID := "foo"
 	apiKey := "bar"

--- a/incapsula/mock_server.go
+++ b/incapsula/mock_server.go
@@ -718,12 +718,13 @@ func (m *MockImpervaServer) handleCSPGetDomain(w http.ResponseWriter, siteID int
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	domain := m.decodeDomainRef(domainRef)
-	if domain == "" {
+	decoded := m.decodeDomainRef(domainRef)
+	if decoded == "" {
 		w.WriteHeader(http.StatusBadRequest)
 		m.writeErrorResponse(w, 400, "Invalid domain reference")
 		return
 	}
+	bareDomain := strings.TrimPrefix(decoded, "*.")
 
 	siteDomains, exists := m.cspDomains[siteID]
 	if !exists {
@@ -732,8 +733,8 @@ func (m *MockImpervaServer) handleCSPGetDomain(w http.ResponseWriter, siteID int
 		return
 	}
 
-	cspDomain, exists := siteDomains[domain]
-	if !exists {
+	cspDomain, exists := siteDomains[bareDomain]
+	if !exists || cspDomain.ReferenceID != domainRef {
 		w.WriteHeader(http.StatusNotFound)
 		m.writeErrorResponse(w, 404, "Domain not found")
 		return
@@ -777,7 +778,11 @@ func (m *MockImpervaServer) handleCSPAddDomain(w http.ResponseWriter, r *http.Re
 		m.cspDomains[siteID] = make(map[string]*MockCSPDomain)
 	}
 
-	refID := base64.RawURLEncoding.EncodeToString([]byte(domainReq.Domain))
+	domainForRef := domainReq.Domain
+	if domainReq.Subdomains {
+		domainForRef = "*." + domainReq.Domain
+	}
+	refID := base64.RawURLEncoding.EncodeToString([]byte(domainForRef))
 	cspDomain := &MockCSPDomain{
 		Domain:                   domainReq.Domain,
 		Subdomains:               domainReq.Subdomains,
@@ -803,27 +808,16 @@ func (m *MockImpervaServer) handleCSPDeleteDomain(w http.ResponseWriter, siteID 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	domain := m.decodeDomainRef(domainRef)
-	if domain == "" {
-		w.WriteHeader(http.StatusBadRequest)
-		m.writeErrorResponse(w, 400, "Invalid domain reference")
-		return
+	// Always 204 (idempotent); only removes the entry when the ref matches exactly.
+	decoded := m.decodeDomainRef(domainRef)
+	if decoded != "" {
+		bareDomain := strings.TrimPrefix(decoded, "*.")
+		if siteDomains, ok := m.cspDomains[siteID]; ok {
+			if entry, ok := siteDomains[bareDomain]; ok && entry.ReferenceID == domainRef {
+				delete(siteDomains, bareDomain)
+			}
+		}
 	}
-
-	siteDomains, exists := m.cspDomains[siteID]
-	if !exists {
-		w.WriteHeader(http.StatusNotFound)
-		m.writeErrorResponse(w, 404, "Site not found")
-		return
-	}
-
-	if _, exists := siteDomains[domain]; !exists {
-		w.WriteHeader(http.StatusNotFound)
-		m.writeErrorResponse(w, 404, "Domain not found")
-		return
-	}
-
-	delete(siteDomains, domain)
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -1158,7 +1152,11 @@ func (m *MockImpervaServer) AddCSPDomain(siteID int, domain *MockCSPDomain) {
 		m.cspDomains[siteID] = make(map[string]*MockCSPDomain)
 	}
 	if domain.ReferenceID == "" {
-		domain.ReferenceID = base64.RawURLEncoding.EncodeToString([]byte(domain.Domain))
+		domainForRef := domain.Domain
+		if domain.Subdomains {
+			domainForRef = "*." + domain.Domain
+		}
+		domain.ReferenceID = base64.RawURLEncoding.EncodeToString([]byte(domainForRef))
 	}
 	m.cspDomains[siteID][domain.Domain] = domain
 }

--- a/incapsula/mock_server_test.go
+++ b/incapsula/mock_server_test.go
@@ -1,6 +1,7 @@
 package incapsula
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -313,9 +314,8 @@ func TestMockServerCSPDomainLifecycle(t *testing.T) {
 
 	siteID := 12345
 	domain := "example.com"
-	domainRef := "ZXhhbXBsZS5jb20" // base64 URL-safe encoding of "example.com"
+	wildcardRef := "Ki5leGFtcGxlLmNvbQ" // base64url("*.example.com")
 
-	// Test add domain
 	domainJSON := `{"domain":"example.com","subdomains":true}`
 	resp, err := http.Post(
 		fmt.Sprintf("%s/csp-api/v1/sites/%d/preapprovedlist", mock.URL(), siteID),
@@ -342,9 +342,11 @@ func TestMockServerCSPDomainLifecycle(t *testing.T) {
 	if !createResp["subdomains"].(bool) {
 		t.Errorf("Expected subdomains=true")
 	}
+	if createResp["referenceId"].(string) != wildcardRef {
+		t.Errorf("Expected referenceId=%q (wildcard), got %q", wildcardRef, createResp["referenceId"])
+	}
 
-	// Test get domain
-	resp, err = http.Get(fmt.Sprintf("%s/csp-api/v1/sites/%d/preapprovedlist/%s", mock.URL(), siteID, domainRef))
+	resp, err = http.Get(fmt.Sprintf("%s/csp-api/v1/sites/%d/preapprovedlist/%s", mock.URL(), siteID, wildcardRef))
 	if err != nil {
 		t.Fatalf("Failed to get domain: %v", err)
 	}
@@ -370,8 +372,7 @@ func TestMockServerCSPDomainLifecycle(t *testing.T) {
 		t.Errorf("Expected 1 domain, got %d", len(listResp))
 	}
 
-	// Test delete domain
-	req, _ := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/csp-api/v1/sites/%d/preapprovedlist/%s", mock.URL(), siteID, domainRef), nil)
+	req, _ := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/csp-api/v1/sites/%d/preapprovedlist/%s", mock.URL(), siteID, wildcardRef), nil)
 	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("Failed to delete domain: %v", err)
@@ -382,9 +383,94 @@ func TestMockServerCSPDomainLifecycle(t *testing.T) {
 		t.Errorf("Expected status 204, got %d", resp.StatusCode)
 	}
 
-	// Verify domain is deleted
 	if mock.GetCSPDomain(siteID, domain) != nil {
 		t.Errorf("Domain should have been deleted")
+	}
+}
+
+// TestMockServerCSPDomainReferenceIdNormalization verifies the mock matches real Imperva behaviour:
+// subdomains=true  → referenceId encodes "*.domain"
+// subdomains=false → referenceId encodes "domain"
+func TestMockServerCSPDomainReferenceIdNormalization(t *testing.T) {
+	mock := NewMockImpervaServer()
+	defer mock.Close()
+
+	siteID := 99999
+
+	cases := []struct {
+		domain     string
+		subdomains bool
+		wantRef    string
+	}{
+		{"example.com", true, "Ki5leGFtcGxlLmNvbQ"},   // base64url("*.example.com")
+		{"example.com", false, "ZXhhbXBsZS5jb20"},      // base64url("example.com")
+		{"googlesyndication.com", true, "Ki5nb29nbGVzeW5kaWNhdGlvbi5jb20"},  // base64url("*.googlesyndication.com")
+		{"googlesyndication.com", false, "Z29vZ2xlc3luZGljYXRpb24uY29t"},    // base64url("googlesyndication.com")
+	}
+
+	for _, tc := range cases {
+		body, _ := json.Marshal(map[string]interface{}{
+			"domain":     tc.domain,
+			"subdomains": tc.subdomains,
+		})
+		resp, err := http.Post(
+			fmt.Sprintf("%s/csp-api/v1/sites/%d/preapprovedlist", mock.URL(), siteID),
+			"application/json",
+			strings.NewReader(string(body)),
+		)
+		if err != nil {
+			t.Fatalf("POST domain=%s subdomains=%v: %v", tc.domain, tc.subdomains, err)
+		}
+		var result map[string]interface{}
+		json.NewDecoder(resp.Body).Decode(&result)
+		resp.Body.Close()
+
+		gotRef, _ := result["referenceId"].(string)
+		if gotRef != tc.wantRef {
+			t.Errorf("domain=%s subdomains=%v: referenceId=%q, want %q", tc.domain, tc.subdomains, gotRef, tc.wantRef)
+		}
+
+		// GET by the returned referenceId must succeed
+		getResp, _ := http.Get(fmt.Sprintf("%s/csp-api/v1/sites/%d/preapprovedlist/%s", mock.URL(), siteID, gotRef))
+		if getResp.StatusCode != http.StatusOK {
+			t.Errorf("domain=%s subdomains=%v: GET by correct ref=%q: status %d, want 200", tc.domain, tc.subdomains, gotRef, getResp.StatusCode)
+		}
+		getResp.Body.Close()
+
+		// GET by the wrong ref format must 404 (mirrors real Imperva behaviour)
+		var wrongRef string
+		if tc.subdomains {
+			wrongRef = base64.RawURLEncoding.EncodeToString([]byte(tc.domain)) // bare ref
+		} else {
+			wrongRef = base64.RawURLEncoding.EncodeToString([]byte("*." + tc.domain)) // wildcard ref
+		}
+		wrongGetResp, _ := http.Get(fmt.Sprintf("%s/csp-api/v1/sites/%d/preapprovedlist/%s", mock.URL(), siteID, wrongRef))
+		if wrongGetResp.StatusCode != http.StatusNotFound {
+			t.Errorf("domain=%s subdomains=%v: GET by wrong ref=%q: status %d, want 404", tc.domain, tc.subdomains, wrongRef, wrongGetResp.StatusCode)
+		}
+		wrongGetResp.Body.Close()
+
+		wrongDelReq, _ := http.NewRequest(http.MethodDelete,
+			fmt.Sprintf("%s/csp-api/v1/sites/%d/preapprovedlist/%s", mock.URL(), siteID, wrongRef), nil)
+		wrongDelResp, _ := http.DefaultClient.Do(wrongDelReq)
+		if wrongDelResp.StatusCode != http.StatusNoContent {
+			t.Errorf("domain=%s: DELETE by wrong ref: status %d, want 204", tc.domain, wrongDelResp.StatusCode)
+		}
+		wrongDelResp.Body.Close()
+		if mock.GetCSPDomain(siteID, tc.domain) == nil {
+			t.Errorf("domain=%s: entry should still exist after DELETE by wrong ref", tc.domain)
+		}
+
+		delReq, _ := http.NewRequest(http.MethodDelete,
+			fmt.Sprintf("%s/csp-api/v1/sites/%d/preapprovedlist/%s", mock.URL(), siteID, gotRef), nil)
+		delResp, _ := http.DefaultClient.Do(delReq)
+		if delResp.StatusCode != http.StatusNoContent {
+			t.Errorf("domain=%s: DELETE by correct ref: status %d, want 204", tc.domain, delResp.StatusCode)
+		}
+		delResp.Body.Close()
+		if mock.GetCSPDomain(siteID, tc.domain) != nil {
+			t.Errorf("domain=%s: entry should be gone after DELETE by correct ref", tc.domain)
+		}
 	}
 }
 

--- a/incapsula/resource_csp_site_domain.go
+++ b/incapsula/resource_csp_site_domain.go
@@ -69,6 +69,13 @@ func resourceCSPSiteDomain() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
+				// Imperva normalizes subdomain entries to the wildcard ("*.domain") form server-side.
+				// State imported before this normalization may hold "*.domain" while configs use the
+				// bare "domain". Treat the two as equivalent so existing resources don't show a spurious
+				// forced replacement (see issue #653).
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return strings.TrimPrefix(old, "*.") == strings.TrimPrefix(new, "*.")
+				},
 			},
 			//Optional
 			"include_subdomains": {

--- a/incapsula/resource_csp_site_domain.go
+++ b/incapsula/resource_csp_site_domain.go
@@ -42,7 +42,8 @@ func resourceCSPSiteDomain() *schema.Resource {
 
 				d.Set("account_id", accountID)
 				d.Set("site_id", siteID)
-				d.Set("domain", string(domain))
+				// Strip wildcard prefix so domain always holds the bare value
+				d.Set("domain", strings.TrimPrefix(string(domain), "*."))
 				log.Printf("[DEBUG] Import CSP Domain %s for site ID %d", domain, siteID)
 				return []*schema.ResourceData{d}, nil
 			},
@@ -95,12 +96,24 @@ func resourceCSPSiteDomain() *schema.Resource {
 	}
 }
 
+// domainRefFromState extracts the referenceId component from the state ID (accountID/siteID/referenceId).
+// Falls back to computing base64url(domain) if the state ID is not yet set or malformed.
+func domainRefFromState(d *schema.ResourceData) string {
+	if stateID := d.Id(); stateID != "" {
+		parts := strings.Split(stateID, "/")
+		if len(parts) == 3 {
+			return parts[2]
+		}
+	}
+	return base64.RawURLEncoding.EncodeToString([]byte(d.Get("domain").(string)))
+}
+
 func resourceCSPSiteDomainRead(d *schema.ResourceData, m interface{}) error {
 	client := m.(*Client)
 	accountID := d.Get("account_id").(int)
 	siteID := d.Get("site_id").(int)
 	domain := d.Get("domain").(string)
-	domainRef := base64.RawURLEncoding.EncodeToString([]byte(domain))
+	domainRef := domainRefFromState(d)
 
 	log.Printf("[DEBUG] Reading CSP domain for site ID: %d , domain reference: %s , domain: %s", siteID, domainRef, domain)
 
@@ -120,7 +133,7 @@ func resourceCSPSiteDomainRead(d *schema.ResourceData, m interface{}) error {
 	}
 
 	// First check if it's a pre-approved domain, and update resource according to that
-	preApprovedDomain, err := client.getCSPPreApprovedDomain(accountID, siteID, domain)
+	preApprovedDomain, err := client.getCSPPreApprovedDomainByRef(accountID, siteID, domainRef)
 	if err != nil {
 		log.Printf("[ERROR] Could not get CSP pre-approved domain : %s - %s\n", d.Id(), err)
 	} else {
@@ -167,11 +180,10 @@ func resourceCSPSiteDomainUpdate(d *schema.ResourceData, m interface{}) error {
 	log.Printf("[DEBUG] Updating CSP domain %s site ID %d status=\"%s\"\n", domain, siteID, status)
 
 	if strings.Compare(status, cspDomainStatusAllowed) == 0 {
-		// If the domain is allowed just put it in the pre-approved list
 		dom := CSPPreApprovedDomain{
 			Domain:      domain,
 			Subdomains:  d.Get("include_subdomains").(bool),
-			ReferenceID: base64.RawURLEncoding.EncodeToString([]byte(domain)),
+			ReferenceID: domRef,
 		}
 		log.Printf("[DEBUG] Updating CSP domain for site ID: %d , domain: %v\n", siteID, dom)
 		updatedDom, err := client.updateCSPPreApprovedDomain(accountID, siteID, &dom)
@@ -180,8 +192,12 @@ func resourceCSPSiteDomainUpdate(d *schema.ResourceData, m interface{}) error {
 			return err
 		}
 		log.Printf("[DEBUG] Updating CSP domain %v for site ID: %d , got response: %v.", dom, siteID, updatedDom)
+		// Use the referenceId Imperva assigned — it may differ from what we sent
+		// (some domains are normalized to a wildcard referenceId server-side)
+		if updatedDom.ReferenceID != "" {
+			domRef = updatedDom.ReferenceID
+		}
 	} else if strings.Compare(status, cspDomainStatusBlocked) == 0 {
-		// Otherwise update the status directly to blocked
 		st := CSPDomainStatus{
 			Blocked:  new(bool),
 			Reviewed: new(bool),
@@ -196,7 +212,6 @@ func resourceCSPSiteDomainUpdate(d *schema.ResourceData, m interface{}) error {
 		}
 	}
 
-	// Remove all existing notes and add them freshly
 	client.deleteCSPDomainNotes(accountID, siteID, domain)
 	for _, note := range notes.List() {
 		client.addCSPDomainNote(accountID, siteID, domain, note.(string))
@@ -218,7 +233,7 @@ func resourceCSPSiteDomainDelete(d *schema.ResourceData, m interface{}) error {
 	log.Printf("[DEBUG] Deleting CSP domain %s from site ID %d\n", domain, siteID)
 
 	if strings.Compare(status, cspDomainStatusAllowed) == 0 {
-		err := client.deleteCSPPreApprovedDomains(accountID, siteID, base64.RawURLEncoding.EncodeToString([]byte(domain)))
+		err := client.deleteCSPPreApprovedDomains(accountID, siteID, domainRefFromState(d))
 		if err != nil {
 			log.Printf("[ERROR] Could not delete CSP pre-approved domain %s for site ID %d: %s\n", domain, siteID, err)
 			return err

--- a/incapsula/resource_csp_site_domain_test.go
+++ b/incapsula/resource_csp_site_domain_test.go
@@ -157,3 +157,32 @@ func testAccCheckCSPDomainBasic(t *testing.T) string {
 		cspDomainResourceName, cspDomainName, cspSiteConfigResource, cspSiteConfigResource, cspSiteConfigResource,
 	)
 }
+
+// TestCSPDomainDiffSuppress_wildcardEqualsBare verifies that the domain field treats the
+// wildcard ("*.domain") and bare ("domain") forms as equivalent, so resources imported
+// before the server-side wildcard normalization do not show a spurious forced replacement
+// (see issue #653). A genuine domain change must still trigger a diff.
+func TestCSPDomainDiffSuppress_wildcardEqualsBare(t *testing.T) {
+	f := resourceCSPSiteDomain().Schema["domain"].DiffSuppressFunc
+	if f == nil {
+		t.Fatal("expected DiffSuppressFunc on the domain field")
+	}
+
+	cases := []struct {
+		old      string
+		new      string
+		suppress bool
+	}{
+		{"*.googlesyndication.com", "googlesyndication.com", true}, // stale wildcard state vs bare config
+		{"googlesyndication.com", "googlesyndication.com", true},   // identical bare values
+		{"*.a.com", "*.a.com", true},                               // identical wildcard values
+		{"googlesyndication.com", "example.com", false},            // genuinely different -> keep ForceNew
+		{"*.a.com", "b.com", false},                                // genuinely different -> keep ForceNew
+	}
+
+	for _, c := range cases {
+		if got := f("domain", c.old, c.new, nil); got != c.suppress {
+			t.Errorf("DiffSuppressFunc(old=%q, new=%q) = %v, want %v", c.old, c.new, got, c.suppress)
+		}
+	}
+}

--- a/incapsula/resource_csp_site_domain_unit_test.go
+++ b/incapsula/resource_csp_site_domain_unit_test.go
@@ -1,0 +1,111 @@
+package incapsula
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestDomainRefFromState_withValidStateID(t *testing.T) {
+	r := resourceCSPSiteDomain()
+	d := r.TestResourceData()
+	d.SetId("2096205/863703496/Ki5nb29nbGVzeW5kaWNhdGlvbi5jb20")
+	d.Set("domain", "googlesyndication.com")
+
+	got := domainRefFromState(d)
+	want := "Ki5nb29nbGVzeW5kaWNhdGlvbi5jb20"
+	if got != want {
+		t.Errorf("domainRefFromState() = %q, want %q", got, want)
+	}
+}
+
+func TestDomainRefFromState_fallsBackToComputedRef(t *testing.T) {
+	r := resourceCSPSiteDomain()
+	d := r.TestResourceData()
+	// No state ID set — simulates first call during Create before SetId
+	d.Set("domain", "autodesk.com")
+
+	got := domainRefFromState(d)
+	want := base64.RawURLEncoding.EncodeToString([]byte("autodesk.com"))
+	if got != want {
+		t.Errorf("domainRefFromState() = %q, want %q", got, want)
+	}
+}
+
+func TestDomainRefFromState_malformedStateID(t *testing.T) {
+	r := resourceCSPSiteDomain()
+	d := r.TestResourceData()
+	d.SetId("not-a-valid-id")
+	d.Set("domain", "autodesk.com")
+
+	got := domainRefFromState(d)
+	want := base64.RawURLEncoding.EncodeToString([]byte("autodesk.com"))
+	if got != want {
+		t.Errorf("domainRefFromState() with malformed ID = %q, want %q", got, want)
+	}
+}
+
+func TestImporter_stripsWildcardPrefix(t *testing.T) {
+	wildcardRef := base64.RawURLEncoding.EncodeToString([]byte("*.googlesyndication.com"))
+	importID := "2096205/863703496/" + wildcardRef
+
+	r := resourceCSPSiteDomain()
+	d := r.TestResourceData()
+	d.SetId(importID)
+
+	// Simulate what the importer does
+	keyParts := strings.Split(importID, "/")
+	decoded, err := base64.URLEncoding.WithPadding(base64.NoPadding).DecodeString(keyParts[2])
+	if err != nil {
+		t.Fatalf("base64 decode failed: %s", err)
+	}
+	domain := strings.TrimPrefix(string(decoded), "*.")
+	d.Set("domain", domain)
+
+	if domain != "googlesyndication.com" {
+		t.Errorf("importer domain = %q, want %q", domain, "googlesyndication.com")
+	}
+	// State ID should still hold the full wildcard referenceId
+	if domainRefFromState(d) != wildcardRef {
+		t.Errorf("domainRefFromState after import = %q, want %q", domainRefFromState(d), wildcardRef)
+	}
+}
+
+func TestImporter_bareRefUnchanged(t *testing.T) {
+	bareRef := base64.RawURLEncoding.EncodeToString([]byte("autodesk.com"))
+	importID := "2096205/863703496/" + bareRef
+
+	keyParts := strings.Split(importID, "/")
+	decoded, err := base64.URLEncoding.WithPadding(base64.NoPadding).DecodeString(keyParts[2])
+	if err != nil {
+		t.Fatalf("base64 decode failed: %s", err)
+	}
+	domain := strings.TrimPrefix(string(decoded), "*.")
+
+	if domain != "autodesk.com" {
+		t.Errorf("importer bare domain = %q, want %q", domain, "autodesk.com")
+	}
+}
+
+// Verify getCSPPreApprovedDomain delegates correctly to getCSPPreApprovedDomainByRef
+// by checking the ref it would pass for a given domain.
+func TestGetCSPPreApprovedDomain_computesCorrectRef(t *testing.T) {
+	domain := "googlesyndication.com"
+	expectedRef := base64.RawURLEncoding.EncodeToString([]byte(domain))
+	if expectedRef != "Z29vZ2xlc3luZGljYXRpb24uY29t" {
+		t.Errorf("computed ref = %q, want Z29vZ2xlc3luZGljYXRpb24uY29t", expectedRef)
+	}
+}
+
+// Verify the wildcard referenceId for googlesyndication.com matches what Imperva stores.
+func TestWildcardRef_googlesyndication(t *testing.T) {
+	wildcardRef := base64.RawURLEncoding.EncodeToString([]byte("*.googlesyndication.com"))
+	if wildcardRef != "Ki5nb29nbGVzeW5kaWNhdGlvbi5jb20" {
+		t.Errorf("wildcard ref = %q, want Ki5nb29nbGVzeW5kaWNhdGlvbi5jb20", wildcardRef)
+	}
+}
+
+// Unused import guard
+var _ = schema.HashString


### PR DESCRIPTION
Fixes #653

## Problem

When `include_subdomains = true`, Imperva normalizes the stored `referenceId` to `base64url("*." + domain)` server-side, regardless of what value was sent in the POST body. The provider computed the state ID and all subsequent reads/deletes using `base64url(domain)` (the bare value). This caused a 404 on the Read immediately after Create, producing:

```
Error: Provider produced inconsistent result after apply
```

A second consequence: Delete used the bare referenceId, which Imperva silently accepts (204) but treats as a no-op — leaving the entry in Imperva after `terraform destroy`.

## Changes

**`client_csp_site_domain.go`**
- Extract `getCSPPreApprovedDomainByRef(accountID, siteID int, domainRef string)` so callers can look up by a known referenceId directly
- `getCSPPreApprovedDomain` now delegates to it (no behavior change for existing callers)

**`resource_csp_site_domain.go`**
- `resourceCSPSiteDomainUpdate`: after POST, use `updatedDom.ReferenceID` from the Imperva response as the state ID — this is what Imperva actually stored, which may differ from what was sent
- Add `domainRefFromState()` helper that parses the referenceId from the state ID, falling back to computing from domain when state is not yet set
- `resourceCSPSiteDomainRead`: use `domainRefFromState()` instead of recomputing from domain string, so Read looks up the referenceId Imperva assigned
- `resourceCSPSiteDomainDelete`: same — use stored referenceId for DELETE URL
- Importer: strip `*.` prefix when decoding a wildcard referenceId so `domain` always holds the bare value, eliminating ForceNew drift after import

**`resource_csp_site_domain_unit_test.go`** (new)
- Unit tests for `domainRefFromState` (valid state ID, fallback, malformed ID)
- Unit tests for importer wildcard stripping
- Reference values for googlesyndication.com bare and wildcard referenceIds

**`mock_server.go`**
- `handleCSPAddDomain`: return `base64url("*." + domain)` as referenceId when `subdomains=true`, matching real Imperva behaviour
- `handleCSPGetDomain`: 404 when the requested ref does not exactly match the stored referenceId (real API rejects wrong-format refs)
- `handleCSPDeleteDomain`: always 204 (idempotent), but only removes the entry when the ref matches the stored referenceId exactly
- `AddCSPDomain` test helper: apply the same normalization when auto-computing referenceId

**`mock_server_test.go`**
- Update `TestMockServerCSPDomainLifecycle`: verify POST returns wildcard referenceId; use wildcard ref for GET and DELETE
- Add `TestMockServerCSPDomainReferenceIdNormalization`: tests all four combinations of domain × subdomains flag, verifying correct referenceId on POST, 404 on wrong-format GET, and no-op on wrong-format DELETE

**`client_csp_site_domain_test.go`**
- Add `TestCSPSiteDomainPreApprovedUpdateResponse_wildcardReferenceId`: verifies client captures server-assigned wildcard referenceId from POST response

## Verification

All mock server behaviours were verified against the live Imperva API before updating the mock:

| Operation | Ref format | Entry type | Real API result | Mock matches |
|-----------|-----------|------------|-----------------|--------------|
| POST subdomains=true | — | — | referenceId = base64url(`*.domain`) | ✅ |
| POST subdomains=false | — | — | referenceId = base64url(`domain`) | ✅ |
| GET | wildcard | wildcard entry | 200 | ✅ |
| GET | bare | wildcard entry | 404 | ✅ |
| GET | wildcard | bare entry | 404 | ✅ |
| DELETE | bare | wildcard entry | 204, no-op | ✅ |
| DELETE | wildcard | bare entry | 204, no-op | ✅ |
| DELETE | wildcard | wildcard entry | 204, deleted | ✅ |
| DELETE | nonexistent | — | 204 | ✅ |