### PR TITLE
Added HTTP 429 rate-limit retry with exponential backoff for API Security resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ FEATURES:
 BUT FIXES:
 - fix: Add retry with exponential backoff for transient API failures ([#663](https://github.com/imperva/terraform-provider-incapsula/pull/663))
 
+IMPROVEMENTS:
+- Added HTTP 429 rate-limit retry with exponential backoff for API Security resources
+
 
 ## 3.38.3 (Jun 1, 2026)
 
@@ -94,7 +97,6 @@ BUG FIXES:
 
 BUG FIXES:
 - Parse error while converting from int to int64. Added a fix to convert it properly. ([#578](https://github.com/imperva/terraform-provider-incapsula/pull/578))
-
 
 
 ## 3.34.1 (Jun 09, 2025)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.40.0 (Aug 5, 2026)
+IMPROVEMENTS:
+- Added HTTP 429 rate-limit retry with exponential backoff for API Security resources
+
 ## 3.39.0 (Jul 22, 2026)
 
 FEATURES:
@@ -5,10 +9,6 @@ FEATURES:
 
 BUT FIXES:
 - fix: Add retry with exponential backoff for transient API failures ([#663](https://github.com/imperva/terraform-provider-incapsula/pull/663))
-
-IMPROVEMENTS:
-- Added HTTP 429 rate-limit retry with exponential backoff for API Security resources
-
 
 ## 3.38.3 (Jun 1, 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,3 @@
-## 3.40.0 (Aug 5, 2026)
-
-IMPROVEMENTS:
-- Added HTTP 429 rate-limit retry with exponential backoff for API Security resources
-
 ## 3.39.1 (Aug 11, 2026)
 
 BUT FIXES:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -6,7 +6,7 @@ NAMESPACE=terraform-providers
 PKG_NAME=incapsula
 BINARY=terraform-provider-${PKG_NAME}
 # Whenever bumping provider version, please update the version in incapsula/client.go (line 27) as well.
-VERSION=3.39.0
+VERSION=3.40.0
 
 # Mac Intel Chip
 #OS_ARCH=darwin_amd64

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -7,7 +7,7 @@ PKG_NAME=incapsula
 BINARY=terraform-provider-${PKG_NAME}
 # Whenever bumping provider version, please update the version in incapsula/client.go (line 27) as well.
 
-VERSION=3.40.0
+VERSION=3.39.1
 
 # Mac Intel Chip
 #OS_ARCH=darwin_amd64

--- a/incapsula/api_security_retry.go
+++ b/incapsula/api_security_retry.go
@@ -1,0 +1,43 @@
+package incapsula
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"time"
+)
+
+func retryOnRateLimit(fn func() (*http.Response, error), initialDelay time.Duration) (*http.Response, error) {
+	delay := initialDelay
+	for attempt := 0; attempt < 5; attempt++ {
+		resp, err := fn()
+		if err != nil {
+			return nil, err
+		}
+		if resp.StatusCode != http.StatusTooManyRequests {
+			return resp, nil
+		}
+		body, _ := ioutil.ReadAll(resp.Body)
+		resp.Body.Close()
+		log.Printf("[DEBUG] API Security 429 response body: %s", string(body))
+		if attempt < 4 {
+			log.Printf("[WARN] API Security request rate limited (429), retrying in %s (attempt %d/5)", delay, attempt+1)
+			time.Sleep(delay)
+			delay *= 2
+		}
+	}
+	return nil, fmt.Errorf("API Security request rate limited after 5 attempts")
+}
+
+func (c *Client) DoApiSecurityJsonRequest(method, url string, data []byte, operation string) (*http.Response, error) {
+	return retryOnRateLimit(func() (*http.Response, error) {
+		return c.DoJsonRequestWithHeaders(method, url, data, operation)
+	}, 10*time.Second)
+}
+
+func (c *Client) DoApiSecurityFormDataRequest(method, url string, data []byte, contentType, operation string) (*http.Response, error) {
+	return retryOnRateLimit(func() (*http.Response, error) {
+		return c.DoFormDataRequestWithHeaders(method, url, data, contentType, operation)
+	}, 10*time.Second)
+}

--- a/incapsula/api_security_retry.go
+++ b/incapsula/api_security_retry.go
@@ -33,11 +33,11 @@ func retryOnRateLimit(fn func() (*http.Response, error), initialDelay time.Durat
 func (c *Client) DoApiSecurityJsonRequest(method, url string, data []byte, operation string) (*http.Response, error) {
 	return retryOnRateLimit(func() (*http.Response, error) {
 		return c.DoJsonRequestWithHeaders(method, url, data, operation)
-	}, 10*time.Second)
+	}, 5*time.Second)
 }
 
 func (c *Client) DoApiSecurityFormDataRequest(method, url string, data []byte, contentType, operation string) (*http.Response, error) {
 	return retryOnRateLimit(func() (*http.Response, error) {
 		return c.DoFormDataRequestWithHeaders(method, url, data, contentType, operation)
-	}, 10*time.Second)
+	}, 5*time.Second)
 }

--- a/incapsula/api_security_retry_test.go
+++ b/incapsula/api_security_retry_test.go
@@ -1,0 +1,148 @@
+package incapsula
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func makeResponse(statusCode int) *http.Response {
+	return &http.Response{
+		StatusCode: statusCode,
+		Body:       http.NoBody,
+	}
+}
+
+func TestRetryOnRateLimit_SuccessFirstAttempt(t *testing.T) {
+	calls := 0
+	fn := func() (*http.Response, error) {
+		calls++
+		return makeResponse(http.StatusOK), nil
+	}
+
+	resp, err := retryOnRateLimit(fn, 0)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 call, got %d", calls)
+	}
+}
+
+func TestRetryOnRateLimit_SuccessAfterOneRetry(t *testing.T) {
+	calls := 0
+	fn := func() (*http.Response, error) {
+		calls++
+		if calls == 1 {
+			return makeResponse(http.StatusTooManyRequests), nil
+		}
+		return makeResponse(http.StatusOK), nil
+	}
+
+	resp, err := retryOnRateLimit(fn, time.Millisecond)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+	if calls != 2 {
+		t.Errorf("expected 2 calls, got %d", calls)
+	}
+}
+
+func TestRetryOnRateLimit_SuccessAfterFourRetries(t *testing.T) {
+	calls := 0
+	fn := func() (*http.Response, error) {
+		calls++
+		if calls <= 4 {
+			return makeResponse(http.StatusTooManyRequests), nil
+		}
+		return makeResponse(http.StatusOK), nil
+	}
+
+	resp, err := retryOnRateLimit(fn, time.Millisecond)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+	if calls != 5 {
+		t.Errorf("expected 5 calls, got %d", calls)
+	}
+}
+
+func TestRetryOnRateLimit_ExhaustsRetries(t *testing.T) {
+	calls := 0
+	fn := func() (*http.Response, error) {
+		calls++
+		return makeResponse(http.StatusTooManyRequests), nil
+	}
+
+	resp, err := retryOnRateLimit(fn, time.Millisecond)
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if err.Error() != "API Security request rate limited after 5 attempts" {
+		t.Errorf("unexpected error message: %s", err)
+	}
+	if resp != nil {
+		t.Errorf("expected nil response, got %v", resp)
+	}
+	if calls != 5 {
+		t.Errorf("expected 5 calls, got %d", calls)
+	}
+}
+
+func TestRetryOnRateLimit_NetworkError(t *testing.T) {
+	calls := 0
+	networkErr := fmt.Errorf("connection refused")
+	fn := func() (*http.Response, error) {
+		calls++
+		return nil, networkErr
+	}
+
+	resp, err := retryOnRateLimit(fn, time.Millisecond)
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if err != networkErr {
+		t.Errorf("expected network error, got: %s", err)
+	}
+	if resp != nil {
+		t.Errorf("expected nil response, got %v", resp)
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 call (no retry on network error), got %d", calls)
+	}
+}
+
+func TestRetryOnRateLimit_NonRateLimitError(t *testing.T) {
+	calls := 0
+	fn := func() (*http.Response, error) {
+		calls++
+		return makeResponse(http.StatusInternalServerError), nil
+	}
+
+	resp, err := retryOnRateLimit(fn, time.Millisecond)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", resp.StatusCode)
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 call (no retry on non-429), got %d", calls)
+	}
+}

--- a/incapsula/client_api_security_api_config.go
+++ b/incapsula/client_api_security_api_config.go
@@ -136,7 +136,7 @@ func (c *Client) CreateApiSecurityApiConfig(siteId int64, apiConfigPayload *ApiS
 
 	reqURL := fmt.Sprintf("%s%s%d", c.config.BaseURLAPI, apiConfigUrl, siteId)
 	contentType := writer.FormDataContentType()
-	resp, err := c.DoFormDataRequestWithHeaders(http.MethodPost, reqURL, body.Bytes(), contentType, CreateApiSecApiConfig)
+	resp, err := c.DoApiSecurityFormDataRequest(http.MethodPost, reqURL, body.Bytes(), contentType, CreateApiSecApiConfig)
 	if err != nil {
 		return nil, fmt.Errorf("[ERROR] Error adding API Security API Config for site %d: %s", siteId, err)
 	}
@@ -187,7 +187,7 @@ func (c *Client) UpdateApiSecurityApiConfig(siteId int64, apiId string, apiConfi
 
 	reqURL := fmt.Sprintf("%s%s%d/%s", c.config.BaseURLAPI, apiConfigUrl, siteId, apiId)
 
-	resp, err := c.DoFormDataRequestWithHeaders(http.MethodPost, reqURL, body, contentType, CreateMtlsClientToImpervaCertifiate)
+	resp, err := c.DoApiSecurityFormDataRequest(http.MethodPost, reqURL, body, contentType, CreateMtlsClientToImpervaCertifiate)
 
 	if err != nil {
 		return nil, fmt.Errorf("[ERROR] Error updating API Security API Config for site id %d, API id %s :%s", siteId, apiId, err)
@@ -280,7 +280,7 @@ func (c *Client) DeleteApiSecurityApiConfig(siteID int64, apiID string) error {
 
 	// Delete request to Incapsula
 	reqURL := fmt.Sprintf("%s%s%d/%s", c.config.BaseURLAPI, apiConfigUrl, siteID, apiID)
-	resp, err := c.DoJsonRequestWithHeaders(http.MethodDelete, reqURL, nil, DeleteApiSecApiConfig)
+	resp, err := c.DoApiSecurityJsonRequest(http.MethodDelete, reqURL, nil, DeleteApiSecApiConfig)
 	if err != nil {
 		return fmt.Errorf("[ERROR] Error from Incapsula service when deleting API Secirity API Config with Site ID %d, API ID %s, : %s", siteID, apiID, err)
 	}

--- a/incapsula/client_api_security_endpoint_config.go
+++ b/incapsula/client_api_security_endpoint_config.go
@@ -69,7 +69,7 @@ func (c *Client) PostApiSecurityEndpointConfig(apiId, endpointId int64, endpoint
 	writer.Close()
 	url := fmt.Sprintf("%s%s%d"+"/"+"%d", c.config.BaseURLAPI, endpointConfigUrl, apiId, endpointId)
 	contentType := writer.FormDataContentType()
-	resp, err := c.DoFormDataRequestWithHeaders(http.MethodPost, url, body.Bytes(), contentType, UpdateApiSecEndpointConfig)
+	resp, err := c.DoApiSecurityFormDataRequest(http.MethodPost, url, body.Bytes(), contentType, UpdateApiSecEndpointConfig)
 	if err != nil {
 		return nil, fmt.Errorf("[ERROR] Error from Incapsula service while updating Api Security Endpoint Configuration for API Config Id %d, API Config Id %d : %s", apiId, endpointId, err)
 	}

--- a/incapsula/client_api_security_site_config.go
+++ b/incapsula/client_api_security_site_config.go
@@ -78,7 +78,7 @@ func (c *Client) UpdateApiSecuritySiteConfig(siteId int64, siteConfigPayload *Ap
 		return nil, fmt.Errorf("Failed to JSON marshal api security site config: %s", err)
 	}
 
-	resp, err := c.DoJsonRequestWithHeaders(http.MethodPost,
+	resp, err := c.DoApiSecurityJsonRequest(http.MethodPost,
 		fmt.Sprintf("%s"+siteConfigUrl+"%d", c.config.BaseURLAPI, siteId),
 		siteConfigJSON,
 		UpdateApiSecSiteConfig)


### PR DESCRIPTION
Added HTTP 429 rate-limit retry with exponential backoff for API Security resources