### PR TITLE
Fix AI Application Security acceptance tests for live backend

### DIFF
--- a/incapsula/resource_ai_application_security_api_key_test.go
+++ b/incapsula/resource_ai_application_security_api_key_test.go
@@ -93,18 +93,16 @@ func TestAiApplicationSecurityApiKeyReadPreservesApplicationIDWhenOmitted(t *tes
 func testAccAiApplicationSecurityApiKeyConfig(name string) string {
 	return fmt.Sprintf(`
 resource "incapsula_ai_application_security_application" "api_key_app" {
-  account_id       = %d
   name             = "api-key-app"
   application_type = "API"
   region           = "US"
 }
 
 resource "incapsula_ai_application_security_api_key" "test" {
-  account_id     = %d
   application_id = incapsula_ai_application_security_application.api_key_app.id
   name           = "%s"
 }
-`, aiApplicationSecurityTestAccountID(), aiApplicationSecurityTestAccountID(), name)
+`, name)
 }
 
 // aiApplicationSecurityApiKeyImportID resolves the import key (numeric API key ID) for the named
@@ -136,7 +134,8 @@ func testAccCheckAiApplicationSecurityApiKeyExists(name string) resource.TestChe
 
 		client := testAccProvider.Meta().(*Client)
 
-		apiKey, err := client.GetAiApplicationSecurityApiKey(aiApplicationSecurityTestAccountID(), apiKeyID)
+		accountID, _ := strconv.Atoi(rs.Primary.Attributes["account_id"])
+		apiKey, err := client.GetAiApplicationSecurityApiKey(accountID, apiKeyID)
 		if err != nil {
 			return fmt.Errorf("Error getting AI Application Security API key: %s", err)
 		}
@@ -164,7 +163,8 @@ func testAccCheckAiApplicationSecurityApiKeyDestroy(s *terraform.State) error {
 			continue
 		}
 
-		apiKey, err := client.GetAiApplicationSecurityApiKey(aiApplicationSecurityTestAccountID(), apiKeyID)
+		accountID, _ := strconv.Atoi(rs.Primary.Attributes["account_id"])
+		apiKey, err := client.GetAiApplicationSecurityApiKey(accountID, apiKeyID)
 		if err == nil && apiKey != nil {
 			return fmt.Errorf("AI Application Security API key still exists: %s", rs.Primary.ID)
 		}

--- a/incapsula/resource_ai_application_security_application_test.go
+++ b/incapsula/resource_ai_application_security_application_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"regexp"
 	"strconv"
 	"testing"
@@ -17,32 +16,6 @@ import (
 const aiApplicationSecurityApplicationApiResourceName = "incapsula_ai_application_security_application.api_test"
 const aiApplicationSecurityApplicationEdgeResourceName = "incapsula_ai_application_security_application.edge_test"
 const aiApplicationSecurityApplicationEdgePartialResourceName = "incapsula_ai_application_security_application.edge_partial"
-
-// aiApplicationSecurityTestAccountID is the account the acceptance tests operate on. It defaults
-// to 1234 (the mock server accepts any account), and is overridable via
-// INCAPSULA_AI_APPLICATION_SECURITY_ACCOUNT_ID when running against a live stage/prod backend where
-// the credentials are scoped to a specific account.
-func aiApplicationSecurityTestAccountID() int {
-	if v := os.Getenv("INCAPSULA_AI_APPLICATION_SECURITY_ACCOUNT_ID"); v != "" {
-		if id, err := strconv.Atoi(v); err == nil {
-			return id
-		}
-	}
-	return 1234
-}
-
-// aiApplicationSecurityTestSiteID is the site the EDGE-type acceptance test attaches to. It defaults
-// to 987654 (the mock server accepts any site), and is overridable via
-// INCAPSULA_AI_APPLICATION_SECURITY_SITE_ID when running against a live backend, which validates that
-// the site exists under the account.
-func aiApplicationSecurityTestSiteID() int {
-	if v := os.Getenv("INCAPSULA_AI_APPLICATION_SECURITY_SITE_ID"); v != "" {
-		if id, err := strconv.Atoi(v); err == nil {
-			return id
-		}
-	}
-	return 987654
-}
 
 // TestAccIncapsulaAiApplicationSecurityApplicationBasic exercises the full API-type resource
 // lifecycle against the mock server: create -> read -> update (name + region via
@@ -129,13 +102,14 @@ func TestAccIncapsulaAiApplicationSecurityApplicationEdge(t *testing.T) {
 		CheckDestroy: testAccCheckAiApplicationSecurityApplicationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAiApplicationSecurityApplicationEdgeConfig("edge-app", "/v1/chat/completions"),
+				Config: testAccAiApplicationSecurityApplicationEdgeConfig(t, "edge-app", "/v1/chat/completions"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAiApplicationSecurityApplicationExists(aiApplicationSecurityApplicationEdgeResourceName),
 					resource.TestCheckResourceAttr(aiApplicationSecurityApplicationEdgeResourceName, "name", "edge-app"),
 					resource.TestCheckResourceAttr(aiApplicationSecurityApplicationEdgeResourceName, "application_type", "EDGE"),
 					resource.TestCheckResourceAttr(aiApplicationSecurityApplicationEdgeResourceName, "configuration.#", "1"),
-					resource.TestCheckResourceAttr(aiApplicationSecurityApplicationEdgeResourceName, "configuration.0.site_id", strconv.Itoa(aiApplicationSecurityTestSiteID())),
+					// site_id is created inline (incapsula_site) and referenced, so compare against it.
+					resource.TestCheckResourceAttrPair(aiApplicationSecurityApplicationEdgeResourceName, "configuration.0.site_id", siteResourceName, "id"),
 					resource.TestCheckResourceAttr(aiApplicationSecurityApplicationEdgeResourceName, "configuration.0.path", "/v1/chat/completions"),
 					resource.TestCheckResourceAttr(aiApplicationSecurityApplicationEdgeResourceName, "configuration.0.is_streaming", "true"),
 					resource.TestCheckResourceAttr(aiApplicationSecurityApplicationEdgeResourceName, "configuration.0.request.#", "1"),
@@ -146,7 +120,7 @@ func TestAccIncapsulaAiApplicationSecurityApplicationEdge(t *testing.T) {
 			},
 			{
 				// Mutate a nested configuration field -> PATCH carrying the whole config block.
-				Config: testAccAiApplicationSecurityApplicationEdgeConfig("edge-app", "/v2/chat/completions"),
+				Config: testAccAiApplicationSecurityApplicationEdgeConfig(t, "edge-app", "/v2/chat/completions"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAiApplicationSecurityApplicationExists(aiApplicationSecurityApplicationEdgeResourceName),
 					resource.TestCheckResourceAttr(aiApplicationSecurityApplicationEdgeResourceName, "configuration.0.path", "/v2/chat/completions"),
@@ -174,7 +148,7 @@ func TestAccIncapsulaAiApplicationSecurityApplicationEdgePartialConfig(t *testin
 		CheckDestroy: testAccCheckAiApplicationSecurityApplicationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAiApplicationSecurityApplicationEdgePartialConfig("edge-partial"),
+				Config: testAccAiApplicationSecurityApplicationEdgePartialConfig(t, "edge-partial"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAiApplicationSecurityApplicationExists(aiApplicationSecurityApplicationEdgePartialResourceName),
 					resource.TestCheckResourceAttr(aiApplicationSecurityApplicationEdgePartialResourceName, "configuration.#", "1"),
@@ -220,24 +194,22 @@ func TestAccIncapsulaAiApplicationSecurityApplicationConfigValidation(t *testing
 func testAccAiApplicationSecurityApplicationConfig(name, region string) string {
 	return fmt.Sprintf(`
 resource "incapsula_ai_application_security_application" "api_test" {
-  account_id       = %d
   name             = "%s"
   application_type = "API"
   region           = "%s"
 }
-`, aiApplicationSecurityTestAccountID(), name, region)
+`, name, region)
 }
 
-func testAccAiApplicationSecurityApplicationEdgeConfig(name, path string) string {
-	return fmt.Sprintf(`
+func testAccAiApplicationSecurityApplicationEdgeConfig(t *testing.T, name, path string) string {
+	return testAccCheckIncapsulaSiteConfigBasic(GenerateTestDomain(t)) + fmt.Sprintf(`
 resource "incapsula_ai_application_security_application" "edge_test" {
-  account_id       = %d
   name             = "%s"
   application_type = "EDGE"
   region           = "US"
 
   configuration {
-    site_id                    = %d
+    site_id                    = incapsula_site.testacc-terraform-site.id
     path                       = "%s"
     content_type               = "application/json"
     prompt_location            = "$.messages[-1].content"
@@ -259,21 +231,20 @@ resource "incapsula_ai_application_security_application" "edge_test" {
     }
   }
 }
-`, aiApplicationSecurityTestAccountID(), name, aiApplicationSecurityTestSiteID(), path)
+`, name, path)
 }
 
 // testAccAiApplicationSecurityApplicationEdgePartialConfig builds an EDGE configuration that contains a
 // request{} block but no response{} block.
-func testAccAiApplicationSecurityApplicationEdgePartialConfig(name string) string {
-	return fmt.Sprintf(`
+func testAccAiApplicationSecurityApplicationEdgePartialConfig(t *testing.T, name string) string {
+	return testAccCheckIncapsulaSiteConfigBasic(GenerateTestDomain(t)) + fmt.Sprintf(`
 resource "incapsula_ai_application_security_application" "edge_partial" {
-  account_id       = %d
   name             = "%s"
   application_type = "EDGE"
   region           = "US"
 
   configuration {
-    site_id                    = %d
+    site_id                    = incapsula_site.testacc-terraform-site.id
     path                       = "/v1/chat/completions"
     prompt_location            = "$.messages[-1].content"
     blocked_response_structure = "{\"error\": \"$BLOCKED_MESSAGE\"}"
@@ -285,24 +256,22 @@ resource "incapsula_ai_application_security_application" "edge_partial" {
     }
   }
 }
-`, aiApplicationSecurityTestAccountID(), name, aiApplicationSecurityTestSiteID())
+`, name)
 }
 
 func testAccAiApplicationSecurityApplicationEdgeMissingConfig(name string) string {
 	return fmt.Sprintf(`
 resource "incapsula_ai_application_security_application" "edge_test" {
-  account_id       = %d
   name             = "%s"
   application_type = "EDGE"
   region           = "US"
 }
-`, aiApplicationSecurityTestAccountID(), name)
+`, name)
 }
 
 func testAccAiApplicationSecurityApplicationSdkWithConfig(name string) string {
 	return fmt.Sprintf(`
 resource "incapsula_ai_application_security_application" "sdk_test" {
-  account_id       = %d
   name             = "%s"
   application_type = "SDK"
   region           = "US"
@@ -311,7 +280,7 @@ resource "incapsula_ai_application_security_application" "sdk_test" {
     path = "/v1/chat/completions"
   }
 }
-`, aiApplicationSecurityTestAccountID(), name)
+`, name)
 }
 
 // aiApplicationSecurityApplicationImportID resolves the import key (application UUID) for the
@@ -338,7 +307,8 @@ func testAccCheckAiApplicationSecurityApplicationExists(name string) resource.Te
 
 		client := testAccProvider.Meta().(*Client)
 
-		app, err := client.GetAiApplicationSecurityApplication(aiApplicationSecurityTestAccountID(), rs.Primary.ID)
+		accountID, _ := strconv.Atoi(rs.Primary.Attributes["account_id"])
+		app, err := client.GetAiApplicationSecurityApplication(accountID, rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("Error getting AI Application Security application: %s", err)
 		}
@@ -361,7 +331,8 @@ func testAccCheckAiApplicationSecurityApplicationDestroy(s *terraform.State) err
 			continue
 		}
 
-		app, err := client.GetAiApplicationSecurityApplication(aiApplicationSecurityTestAccountID(), rs.Primary.ID)
+		accountID, _ := strconv.Atoi(rs.Primary.Attributes["account_id"])
+		app, err := client.GetAiApplicationSecurityApplication(accountID, rs.Primary.ID)
 		if err == nil && app != nil {
 			return fmt.Errorf("AI Application Security application still exists: %s", rs.Primary.ID)
 		}

--- a/incapsula/resource_ai_application_security_policy_test.go
+++ b/incapsula/resource_ai_application_security_policy_test.go
@@ -3,6 +3,7 @@ package incapsula
 import (
 	"fmt"
 	"regexp"
+	"strconv"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -246,14 +247,12 @@ func TestAccIncapsulaAiApplicationSecurityPolicyGuardrailConfigDistinct(t *testi
 func testAccAiApplicationSecurityPolicyConfig(name string, active bool) string {
 	return fmt.Sprintf(`
 resource "incapsula_ai_application_security_application" "policy_app" {
-  account_id       = %d
   name             = "policy-app"
   application_type = "API"
   region           = "US"
 }
 
 resource "incapsula_ai_application_security_policy" "test" {
-  account_id     = %d
   application_id = incapsula_ai_application_security_application.policy_app.id
   name           = "%s"
   active         = %t
@@ -270,7 +269,7 @@ resource "incapsula_ai_application_security_policy" "test" {
     mode  = "ALERT"
   }
 }
-`, aiApplicationSecurityTestAccountID(), aiApplicationSecurityTestAccountID(), name, active)
+`, name, active)
 }
 
 // testAccAiApplicationSecurityPolicyConfigJSONConfig declares a guardrail whose config JSON has multiple
@@ -278,14 +277,12 @@ resource "incapsula_ai_application_security_policy" "test" {
 func testAccAiApplicationSecurityPolicyConfigJSONConfig(name string) string {
 	return fmt.Sprintf(`
 resource "incapsula_ai_application_security_application" "policy_app" {
-  account_id       = %d
   name             = "policy-app"
   application_type = "API"
   region           = "US"
 }
 
 resource "incapsula_ai_application_security_policy" "test" {
-  account_id     = %d
   application_id = incapsula_ai_application_security_application.policy_app.id
   name           = "%s"
 
@@ -296,7 +293,7 @@ resource "incapsula_ai_application_security_policy" "test" {
     config = "{\"z_threshold\":0.9,\"a_enabled\":true}"
   }
 }
-`, aiApplicationSecurityTestAccountID(), aiApplicationSecurityTestAccountID(), name)
+`, name)
 }
 
 // testAccAiApplicationSecurityPolicyGuardrailMutationConfig declares a single PII_STATIC/PROMPT guardrail
@@ -305,14 +302,12 @@ resource "incapsula_ai_application_security_policy" "test" {
 func testAccAiApplicationSecurityPolicyGuardrailMutationConfig(name, mode string, active bool, config string) string {
 	return fmt.Sprintf(`
 resource "incapsula_ai_application_security_application" "policy_app" {
-  account_id       = %d
   name             = "policy-app"
   application_type = "API"
   region           = "US"
 }
 
 resource "incapsula_ai_application_security_policy" "test" {
-  account_id     = %d
   application_id = incapsula_ai_application_security_application.policy_app.id
   name           = "%s"
 
@@ -324,7 +319,7 @@ resource "incapsula_ai_application_security_policy" "test" {
     config = %q
   }
 }
-`, aiApplicationSecurityTestAccountID(), aiApplicationSecurityTestAccountID(), name, mode, active, config)
+`, name, mode, active, config)
 }
 
 // testAccAiApplicationSecurityPolicyOneGuardrailConfig declares a policy with a single guardrail, used to
@@ -332,14 +327,12 @@ resource "incapsula_ai_application_security_policy" "test" {
 func testAccAiApplicationSecurityPolicyOneGuardrailConfig(name string) string {
 	return fmt.Sprintf(`
 resource "incapsula_ai_application_security_application" "policy_app" {
-  account_id       = %d
   name             = "policy-app"
   application_type = "API"
   region           = "US"
 }
 
 resource "incapsula_ai_application_security_policy" "test" {
-  account_id     = %d
   application_id = incapsula_ai_application_security_application.policy_app.id
   name           = "%s"
 
@@ -349,7 +342,7 @@ resource "incapsula_ai_application_security_policy" "test" {
     mode  = "BLOCK"
   }
 }
-`, aiApplicationSecurityTestAccountID(), aiApplicationSecurityTestAccountID(), name)
+`, name)
 }
 
 // testAccAiApplicationSecurityPolicyGuardrailConfigDistinctConfig declares two guardrails that differ ONLY
@@ -359,14 +352,12 @@ resource "incapsula_ai_application_security_policy" "test" {
 func testAccAiApplicationSecurityPolicyGuardrailConfigDistinctConfig(name string) string {
 	return fmt.Sprintf(`
 resource "incapsula_ai_application_security_application" "policy_app" {
-  account_id       = %d
   name             = "policy-app"
   application_type = "API"
   region           = "US"
 }
 
 resource "incapsula_ai_application_security_policy" "test" {
-  account_id     = %d
   application_id = incapsula_ai_application_security_application.policy_app.id
   name           = "%s"
 
@@ -384,20 +375,18 @@ resource "incapsula_ai_application_security_policy" "test" {
     config = "{\"nested\":{\"b\":2,\"a\":1},\"arr\":[3,1,2]}"
   }
 }
-`, aiApplicationSecurityTestAccountID(), aiApplicationSecurityTestAccountID(), name)
+`, name)
 }
 
 func testAccAiApplicationSecurityPolicyInvalidPhaseConfig(name string) string {
 	return fmt.Sprintf(`
 resource "incapsula_ai_application_security_application" "policy_app" {
-  account_id       = %d
   name             = "policy-app"
   application_type = "API"
   region           = "US"
 }
 
 resource "incapsula_ai_application_security_policy" "test" {
-  account_id     = %d
   application_id = incapsula_ai_application_security_application.policy_app.id
   name           = "%s"
 
@@ -407,7 +396,7 @@ resource "incapsula_ai_application_security_policy" "test" {
     mode  = "BLOCK"
   }
 }
-`, aiApplicationSecurityTestAccountID(), aiApplicationSecurityTestAccountID(), name)
+`, name)
 }
 
 // aiApplicationSecurityPolicyImportID resolves the import key (policy UUID) for the named resource
@@ -434,7 +423,8 @@ func testAccCheckAiApplicationSecurityPolicyExists(name string) resource.TestChe
 
 		client := testAccProvider.Meta().(*Client)
 
-		policy, err := client.GetAiApplicationSecurityPolicy(aiApplicationSecurityTestAccountID(), rs.Primary.Attributes["application_id"], rs.Primary.ID)
+		accountID, _ := strconv.Atoi(rs.Primary.Attributes["account_id"])
+		policy, err := client.GetAiApplicationSecurityPolicy(accountID, rs.Primary.Attributes["application_id"], rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("Error getting AI Application Security policy: %s", err)
 		}
@@ -457,7 +447,8 @@ func testAccCheckAiApplicationSecurityPolicyDestroy(s *terraform.State) error {
 			continue
 		}
 
-		policy, err := client.GetAiApplicationSecurityPolicy(aiApplicationSecurityTestAccountID(), rs.Primary.Attributes["application_id"], rs.Primary.ID)
+		accountID, _ := strconv.Atoi(rs.Primary.Attributes["account_id"])
+		policy, err := client.GetAiApplicationSecurityPolicy(accountID, rs.Primary.Attributes["application_id"], rs.Primary.ID)
 		if err == nil && policy != nil {
 			return fmt.Errorf("AI Application Security policy still exists: %s", rs.Primary.ID)
 		}


### PR DESCRIPTION
The acceptance tests hardcoded account_id 1234 (a mock-only placeholder), which the live backend rejected with 401 "Unauthorized request for account: 1234". Remove the hardcoded account_id from all test configs and let the backend resolve the account from the API credentials (the resource omits the caid query param when account_id is 0). Read the account back from state via the repo-standard rs.Primary.Attributes["account_id"] idiom in the Exists/Destroy check helpers.

For the EDGE application tests, which require a real site_id, adopt the repo's inline-site pattern: prepend testAccCheckIncapsulaSiteConfigBasic( GenerateTestDomain(t)) and reference incapsula_site.testacc-terraform-site.id, comparing via TestCheckResourceAttrPair. This matches how site-scoped resources (e.g. incap_rule) are tested and makes the EDGE tests real-backend-only, consistent with the rest of the suite.